### PR TITLE
Update newrelic-infra.sh

### DIFF
--- a/newrelic-infra.sh
+++ b/newrelic-infra.sh
@@ -5,4 +5,4 @@ if [ "$NRIA_DOCKER_ENABLED" = "true" ]; then
     cp /etc/newrelic-infra/integrations.d/docker-config.yml.sample /etc/newrelic-infra/integrations.d/docker-config.yml
 fi
 
-tini -- /usr/bin/newrelic-infra
+tini -- /usr/bin/newrelic-infra-service


### PR DESCRIPTION
In order to enable the command channel feature, the script must execute the service.