### PR TITLE
Update executable prefix from nr- to nri-.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.6.0 (2019-11-20)
+### Changed
+- Renamed the integration executable from nr-docker to nri-docker in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.
+
 ## 0.5.1 - 2019-09-25
 
 - Added support for custom Cgroup parent paths

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ WORKDIR /go/src/github.com/newrelic/nri-docker
 COPY . .
 
 RUN make compile && \
-    strip ./bin/nr-docker
+    strip ./bin/nri-docker
 
 FROM $infra_image
-COPY --from=builder /go/src/github.com/newrelic/nri-docker/bin/nr-docker /var/db/newrelic-infra/newrelic-integrations/bin/nr-docker
+COPY --from=builder /go/src/github.com/newrelic/nri-docker/bin/nri-docker /var/db/newrelic-infra/newrelic-integrations/bin/nri-docker
 COPY --from=builder /go/src/github.com/newrelic/nri-docker/docker-definition.yml /var/db/newrelic-infra/newrelic-integrations/docker-definition.yml
 COPY --from=builder /go/src/github.com/newrelic/nri-docker/docker-config.yml.sample /etc/newrelic-infra/integrations.d/docker-config.yml.sample
 COPY --from=builder /go/src/github.com/newrelic/nri-docker/newrelic-infra.sh /newrelic-infra.sh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 INTEGRATION     := docker
-BINARY_NAME      = nr-$(INTEGRATION)
+BINARY_NAME      = nri-$(INTEGRATION)
 SRC_DIR          = ./src/
 VALIDATE_DEPS    = golang.org/x/lint/golint
 TEST_DEPS        = github.com/axw/gocov/gocov github.com/AlekSi/gocov-xml

--- a/docker-definition.yml
+++ b/docker-definition.yml
@@ -6,5 +6,5 @@ os: linux
 commands:
   all_data:
     command:
-      - ./bin/nr-docker
+      - ./bin/nri-docker
     interval: 15

--- a/src/docker.go
+++ b/src/docker.go
@@ -17,7 +17,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.docker"
-	integrationVersion = "0.5.1"
+	integrationVersion = "0.6.0"
 )
 
 var (


### PR DESCRIPTION
### Changed
- Renamed the integration executable from nr-docker to nri-docker in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.