### PR TITLE
Added back docker-definition

### DIFF
--- a/docker-definition.yml
+++ b/docker-definition.yml
@@ -1,0 +1,11 @@
+name: com.newrelic.docker
+description: Reports status and metrics for nri-docker service
+protocol_version: 1
+os: linux
+
+commands:
+  all_data:
+    command:
+      - ./bin/nri-docker
+    interval: 15
+


### PR DESCRIPTION
This avoids breaking the release of the agent before docker is bundled with it