### PR TITLE
Temporarily put back docker-config sample file

### DIFF
--- a/docker-config.yml.sample
+++ b/docker-config.yml.sample
@@ -1,0 +1,4 @@
+integrations:
+  - name: nri-docker
+    feature: docker_enabled
+    interval: 15s


### PR DESCRIPTION
Otherwise, containerized agent release fails and, in consequence,
integrations release (due to installation check failures)