### PR TITLE
Updating conditional execution to next Agent version

### DIFF
--- a/docker-config.yml
+++ b/docker-config.yml
@@ -1,4 +1,6 @@
 integrations:
   - name: nri-docker
-    feature: docker_enabled
+    when:
+      feature: docker_enabled
+      file_exists: /var/run/docker.sock
     interval: 15s


### PR DESCRIPTION
Next agent version will require:
- Setting the `feature` inside a `when` field
- Using the `file_exists` property to avoid running the integration when docker is not running