### PR TITLE
Detect cgroup path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.2 (2020-02-07)
+### Changed
+Added support for auto-detection of the Cgroup path. The auto-detected Cgroup path
+can be overwritten by the new config parameter 'cgroup_path'.
+
 ## 1.0.1 (2020-01-13)
 ### Changed
 Updated execution conditions for integrations v4.

--- a/src/biz/metrics_test.go
+++ b/src/biz/metrics_test.go
@@ -37,7 +37,7 @@ func TestHighCPU(t *testing.T) {
 	defer docker.Close()
 	metrics := NewProcessor(
 		persist.NewInMemoryStore(),
-		raw.NewFetcher("/"),
+		raw.NewFetcher("/", ""),
 		docker)
 	sample, err := metrics.Process(containerID)
 	require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestLowCPU(t *testing.T) {
 	defer docker.Close()
 	metrics := NewProcessor(
 		persist.NewInMemoryStore(),
-		raw.NewFetcher("/"),
+		raw.NewFetcher("/", ""),
 		docker)
 	sample, err := metrics.Process(containerID)
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestMemory(t *testing.T) {
 	defer docker.Close()
 	metrics := NewProcessor(
 		persist.NewInMemoryStore(),
-		raw.NewFetcher("/"),
+		raw.NewFetcher("/", ""),
 		docker)
 	// Then the Memory metrics are reported according to the usage and limits
 	test.Eventually(t, eventuallyTimeout, func(t require.TestingT) {

--- a/src/biz/metrics_test.go
+++ b/src/biz/metrics_test.go
@@ -37,7 +37,7 @@ func TestHighCPU(t *testing.T) {
 	defer docker.Close()
 	metrics := NewProcessor(
 		persist.NewInMemoryStore(),
-		raw.NewFetcher("/", ""),
+		raw.NewFetcher("/", "", ""),
 		docker)
 	sample, err := metrics.Process(containerID)
 	require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestLowCPU(t *testing.T) {
 	defer docker.Close()
 	metrics := NewProcessor(
 		persist.NewInMemoryStore(),
-		raw.NewFetcher("/", ""),
+		raw.NewFetcher("/", "", ""),
 		docker)
 	sample, err := metrics.Process(containerID)
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestMemory(t *testing.T) {
 	defer docker.Close()
 	metrics := NewProcessor(
 		persist.NewInMemoryStore(),
-		raw.NewFetcher("/", ""),
+		raw.NewFetcher("/", "", ""),
 		docker)
 	// Then the Memory metrics are reported according to the usage and limits
 	test.Eventually(t, eventuallyTimeout, func(t require.TestingT) {

--- a/src/docker.go
+++ b/src/docker.go
@@ -13,6 +13,7 @@ type argumentList struct {
 	Pretty     bool   `default:"false" help:"Print pretty formatted JSON."`
 	NriCluster string `default:"" help:"Optional. Cluster name"`
 	HostRoot   string `default:"/host" help:"If the integration is running from a container, the mounted folder pointing to the host root folder"`
+	CgroupPath string `default:"" help:"Optional. The path where cgroup is mounted."`
 }
 
 const (
@@ -34,7 +35,7 @@ func main() {
 
 	log.SetupLogging(args.Verbose)
 
-	cs, err := nri.NewSampler(args.HostRoot)
+	cs, err := nri.NewSampler(args.HostRoot, args.CgroupPath)
 	exitOnErr(err)
 
 	exitOnErr(cs.SampleAll(i))

--- a/src/nri/sampler.go
+++ b/src/nri/sampler.go
@@ -38,7 +38,7 @@ type dockerClient interface {
 // NewSampler returns a ContainerSampler instance. The hostRoot argument is used only if the integration is
 // executed inside a container, and must point to the shared folder that allows accessing to the host root
 // folder (usually /host)
-func NewSampler(hostRoot string) (ContainerSampler, error) {
+func NewSampler(hostRoot, cgroupPath string) (ContainerSampler, error) {
 	// instantiating internal components
 	// docker client to list and inspect containers
 	docker, err := client.NewEnvClient()
@@ -58,7 +58,7 @@ func NewSampler(hostRoot string) (ContainerSampler, error) {
 	}
 
 	// Raw metrics fetcher to get the raw metrics from the system (cgroups and proc fs)
-	rawFetcher := raw.NewFetcher(hostRoot)
+	rawFetcher := raw.NewFetcher(hostRoot, cgroupPath)
 
 	return ContainerSampler{
 		metrics: biz.NewProcessor(store, rawFetcher, docker),

--- a/src/nri/sampler.go
+++ b/src/nri/sampler.go
@@ -58,7 +58,7 @@ func NewSampler(hostRoot, cgroupPath string) (ContainerSampler, error) {
 	}
 
 	// Raw metrics fetcher to get the raw metrics from the system (cgroups and proc fs)
-	rawFetcher := raw.NewFetcher(hostRoot, cgroupPath)
+	rawFetcher := raw.NewFetcher(hostRoot, cgroupPath, raw.GetMountsFilePath())
 
 	return ContainerSampler{
 		metrics: biz.NewProcessor(store, rawFetcher, docker),

--- a/src/raw/cgroup.go
+++ b/src/raw/cgroup.go
@@ -29,13 +29,13 @@ type cgroupsFetcher struct {
 	subsystems cgroups.Hierarchy
 }
 
-func newCGroupsFetcher(hostRoot, cgroup string) *cgroupsFetcher {
+func newCGroupsFetcher(hostRoot, cgroup, mountsFilePath string) *cgroupsFetcher {
 	if cgroup != "" {
 		// Prepend cgroup to have higher priority than the predefined paths.
 		localCgroupPaths = append([]string{cgroup}, localCgroupPaths...)
 	}
 
-	cgroupPath, err := detectCgroupPath(localCgroupPaths)
+	cgroupPath, err := detectCgroupPath(localCgroupPaths, mountsFilePath)
 	if err != nil {
 		log.Error("couldn't detect cgroup path, error: %v, "+
 			"use cgroup_path config option to set the correct cgroup path", err)
@@ -53,13 +53,13 @@ func newCGroupsFetcher(hostRoot, cgroup string) *cgroupsFetcher {
 // 1. cgroup provided as config parameter to integration
 // 2. predefined list of usual cgroup paths
 // 3. parsing the mounts file.
-func detectCgroupPath(cgroupPaths []string) (string, error) {
+func detectCgroupPath(cgroupPaths []string, mountsFilePath string) (string, error) {
 	path, found := getFirstExistingNonEmptyPath(cgroupPaths)
 	if found {
 		return path, nil
 	}
 
-	mountsFile, err := openMountsFile()
+	mountsFile, err := os.Open(mountsFilePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to open mounts file while detecting cgroup path, error: %v", err)
 	}

--- a/src/raw/cgroup.go
+++ b/src/raw/cgroup.go
@@ -31,12 +31,14 @@ type cgroupsFetcher struct {
 
 func newCGroupsFetcher(hostRoot, cgroup string) *cgroupsFetcher {
 	if cgroup != "" {
+		// Prepend cgroup to have higher priority than the predefined paths.
 		localCgroupPaths = append([]string{cgroup}, localCgroupPaths...)
 	}
 
 	cgroupPath, err := detectCgroupPath(localCgroupPaths)
 	if err != nil {
-		log.Error("couldn't detect cgroup path: %v, use -cgroup_path to set the correct cgroup path", err)
+		log.Error("couldn't detect cgroup path, error: %v, "+
+			"use cgroup_path config option to set the correct cgroup path", err)
 	}
 
 	cgroupPath = containerToHost(hostRoot, cgroupPath)

--- a/src/raw/cgroup.go
+++ b/src/raw/cgroup.go
@@ -36,10 +36,11 @@ func newCGroupsFetcher(hostRoot, cgroup string) *cgroupsFetcher {
 
 	cgroupPath, err := detectCgroupPath(localCgroupPaths)
 	if err != nil {
-		log.Error("couldn't detect cgroup path: %v", err)
+		log.Error("couldn't detect cgroup path: %v, use -cgroup_path to set the correct cgroup path", err)
 	}
 
 	cgroupPath = containerToHost(hostRoot, cgroupPath)
+
 	return &cgroupsFetcher{
 		cgroupPath: cgroupPath,
 		subsystems: subsystems(cgroupPath),
@@ -51,7 +52,7 @@ func newCGroupsFetcher(hostRoot, cgroup string) *cgroupsFetcher {
 // 2. predefined list of usual cgroup paths
 // 3. parsing the mounts file.
 func detectCgroupPath(cgroupPaths []string) (string, error) {
-	path, found := getFirstExistingPath(cgroupPaths)
+	path, found := getFirstExistingNonEmptyPath(cgroupPaths)
 	if found {
 		return path, nil
 	}

--- a/src/raw/cgroup_test.go
+++ b/src/raw/cgroup_test.go
@@ -1,0 +1,31 @@
+package raw
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDetectCgroupPath(t *testing.T) {
+	mounts := []*mount{
+		{
+			Device:     "sysfs",
+			MountPoint: "/sys",
+			FSType:     "sysfs",
+			Options:    "rw,nosuid,nodev,noexec,relatime",
+		},
+		{
+			Device:     "cgroup",
+			MountPoint: "/sys/fs/cgroup/unified",
+			FSType:     "cgroup2",
+			Options:    "rw,nosuid,nodev,noexec,relatime",
+		},
+	}
+
+	result, found := detectCgroupPathFromMounts(mounts[:1])
+	assert.False(t, found)
+	assert.Empty(t, result)
+
+	result, found = detectCgroupPathFromMounts(mounts[1:])
+	assert.True(t, found)
+	assert.Equal(t, "/sys/fs/cgroup", result)
+}

--- a/src/raw/metrics.go
+++ b/src/raw/metrics.go
@@ -80,9 +80,9 @@ type Fetcher interface {
 }
 
 // NewFetcher returns a raw MetricsFetcher
-func NewFetcher(hostRoot string) *MetricsFetcher {
+func NewFetcher(hostRoot, cgroups string) *MetricsFetcher {
 	return &MetricsFetcher{
-		cgroups: newCGroupsFetcher(hostRoot),
+		cgroups: newCGroupsFetcher(hostRoot, cgroups),
 		network: newNetworkFetcher(hostRoot),
 	}
 }

--- a/src/raw/metrics.go
+++ b/src/raw/metrics.go
@@ -80,9 +80,9 @@ type Fetcher interface {
 }
 
 // NewFetcher returns a raw MetricsFetcher
-func NewFetcher(hostRoot, cgroups string) *MetricsFetcher {
+func NewFetcher(hostRoot, cgroups, mountsFilePath string) *MetricsFetcher {
 	return &MetricsFetcher{
-		cgroups: newCGroupsFetcher(hostRoot, cgroups),
+		cgroups: newCGroupsFetcher(hostRoot, cgroups, mountsFilePath),
 		network: newNetworkFetcher(hostRoot),
 	}
 }

--- a/src/raw/util.go
+++ b/src/raw/util.go
@@ -99,8 +99,7 @@ func getMounts(file io.Reader) ([]*mount, error) {
 	return result, nil
 }
 
-func openMountsFile() (*os.File, error) {
-	mountsFile := getEnv(procPathEnvVarName, defaultProcPath, defaultMountsPath)
-
-	return os.Open(mountsFile)
+// GetMountsFilePath will return the path to the system mounts file.
+func GetMountsFilePath() string {
+	return getEnv(procPathEnvVarName, defaultProcPath, defaultMountsPath)
 }

--- a/src/raw/util.go
+++ b/src/raw/util.go
@@ -41,16 +41,33 @@ func getEnv(name, defaultValue string, combineWith ...string) string {
 	return value
 }
 
-// getFirstExistingPath will return the first path in the array that can be accessed.
-func getFirstExistingPath(paths []string) (result string, found bool) {
+// getFirstExistingNonEmptyPath will return the first path in the array that can be accessed.
+func getFirstExistingNonEmptyPath(paths []string) (result string, found bool) {
 	for _, path := range paths {
-		if _, err := os.Stat(path); err == nil {
-			result = path
-			found = true
-			break
+		isEmpty, err := isDirEmpty(path)
+		if err != nil || isEmpty {
+			continue
 		}
+
+		result = path
+		found = true
+		break
 	}
 	return
+}
+func isDirEmpty(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	maxResults := 1
+	_, err = f.Readdirnames(maxResults)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err
 }
 
 type mount struct {

--- a/src/raw/util.go
+++ b/src/raw/util.go
@@ -1,8 +1,17 @@
 package raw
 
 import (
+	"bufio"
+	"io"
 	"os"
 	"path"
+	"strings"
+)
+
+const (
+	procPathEnvVarName = "HOST_PROC"
+	defaultProcPath    = "/proc"
+	defaultMountsPath  = "/mounts"
 )
 
 // returns a path that is located on the root folder of the host and the `/host` folder
@@ -15,4 +24,66 @@ func containerToHost(hostFolder, hostPath string) string {
 		return insideContainerPath
 	}
 	return hostPath
+}
+
+// getEnv will get the environment variable and return a string containing all extra values provided
+// joined with the environment variable. If environment variable is not set, a default value will be used.
+func getEnv(name, defaultValue string, combineWith ...string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		value = defaultValue
+	}
+
+	if len(combineWith) > 0 {
+		value += path.Join(combineWith...)
+	}
+
+	return value
+}
+
+// getFirstExistingPath will return the first path in the array that can be accessed.
+func getFirstExistingPath(paths []string) (result string, found bool) {
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			result = path
+			found = true
+			break
+		}
+	}
+	return
+}
+
+type mount struct {
+	Device     string
+	MountPoint string
+	FSType     string
+	Options    string
+}
+
+// getMounts will parse the provided mounts file into mount structure.
+func getMounts(file io.Reader) ([]*mount, error) {
+	var result []*mount
+
+	sc := bufio.NewScanner(file)
+	for sc.Scan() {
+		line := sc.Text()
+		fields := strings.Fields(line)
+		mount := &mount{
+			Device:     fields[0],
+			MountPoint: fields[1],
+			FSType:     fields[2],
+			Options:    fields[3],
+		}
+		result = append(result, mount)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func openMountsFile() (*os.File, error) {
+	mountsFile := getEnv(procPathEnvVarName, defaultProcPath, defaultMountsPath)
+
+	return os.Open(mountsFile)
 }

--- a/src/raw/util_test.go
+++ b/src/raw/util_test.go
@@ -1,0 +1,100 @@
+package raw
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGetEnv(t *testing.T) {
+	result := getEnv("NRIA_NO_VAR", "/procs")
+	assert.Equal(t, result, "/procs")
+
+	result = getEnv("NRIA_NO_VAR", "/procs", "/test")
+	assert.Equal(t, result, "/procs/test")
+
+	result = getEnv("NRIA_NO_VAR", "/procs", "/test", "/test2")
+	assert.Equal(t, result, "/procs/test/test2")
+
+	os.Setenv("NRIA_NO_VAR", "/diff_path")
+	result = getEnv("NRIA_NO_VAR", "/procs", "/test")
+	assert.Equal(t, result, "/diff_path/test")
+}
+
+func TestGetFirstExistingNonEmptyPath(t *testing.T) {
+	actual, found := getFirstExistingNonEmptyPath([]string{
+		"zzzzzttttteeest",
+	})
+	assert.Equal(t, "", actual)
+	assert.False(t, found)
+
+	tempDir := os.TempDir() + "/TestGetFirstExistingPath"
+	err := os.MkdirAll(tempDir, os.ModePerm)
+	assert.NoError(t, err)
+
+	f, err := ioutil.TempFile(tempDir, "prefix")
+	assert.NoError(t, err)
+
+	defer func() {
+		err := os.Remove(f.Name())
+		assert.NoError(t, err)
+		err = os.Remove(tempDir)
+		assert.NoError(t, err)
+	}()
+
+	actual, found = getFirstExistingNonEmptyPath([]string{
+		"zzzzzttttteeest",
+		tempDir,
+	})
+
+	assert.Equal(t, tempDir, actual)
+	assert.Equal(t, found, true)
+}
+
+var mountsFileContent = `sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec,mode=755 0 0
+cgroup /sys/fs/cgroup/unified cgroup2 rw,nosuid,nodev,noexec,relatime 0 0
+:/Users/cciutea/workspace/nr/gotest/src /go/src fuse.sshfs rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other 0 0
+`
+
+var expectedMounts = []*mount{
+	{
+		Device:     "sysfs",
+		MountPoint: "/sys",
+		FSType:     "sysfs",
+		Options:    "rw,nosuid,nodev,noexec,relatime",
+	},
+	{
+		Device:     "tmpfs",
+		MountPoint: "/sys/fs/cgroup",
+		FSType:     "tmpfs",
+		Options:    "ro,nosuid,nodev,noexec,mode=755",
+	},
+	{
+		Device:     "cgroup",
+		MountPoint: "/sys/fs/cgroup/unified",
+		FSType:     "cgroup2",
+		Options:    "rw,nosuid,nodev,noexec,relatime",
+	},
+	{
+		Device:     ":/Users/cciutea/workspace/nr/gotest/src",
+		MountPoint: "/go/src",
+		FSType:     "fuse.sshfs",
+		Options:    "rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other",
+	},
+}
+
+func TestGetMounts(t *testing.T) {
+	file := strings.NewReader(mountsFileContent)
+
+	mounts, err := getMounts(file)
+	assert.NoError(t, err)
+
+	assert.Equal(t, len(expectedMounts), len(mounts), "unexpected result array size")
+
+	for i, expectedMount := range expectedMounts {
+		assert.Equal(t, *expectedMount, *mounts[i], "actual different than expected")
+	}
+}


### PR DESCRIPTION
This pr will add detection of cgroup location:
1. --cgroup_path command line argument
2. checking existence of cgroup usual paths:
	"/sys/fs/cgroup",
	"/cgroup",
3. parsing mounts file