### PR TITLE
[IHOST-2496] Added memoryUsageLimitPercent and changed memorySizeLimitBytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.0.2 (2020-02-07)
+## Next (TBD)
+
+### Added
+* Metric `memoryUsageLimitPercent` that reports the usage of the container memory as
+  a percentage of the limit. If there is no limit defined, this metric is not reported.
+
+### Changed
+* Metric `memorySizeLimitBytes` is not reported anymore when there is no such limit
+  (before it was reported as `0`)
+
+## 1.1.1 (2020-02-07)
 ### Changed
 Added support for auto-detection of the Cgroup path. The auto-detected Cgroup path
 can be overwritten by the new config parameter 'cgroup_path'.

--- a/src/biz/metrics.go
+++ b/src/biz/metrics.go
@@ -56,6 +56,7 @@ type Memory struct {
 	CacheUsageBytes uint64
 	RSSUsageBytes   uint64
 	MemLimitBytes   uint64
+	UsagePercent    float64 // Usage percent from the limit, if any
 }
 
 // Processer defines the most essential interface of an exportable container Processer
@@ -191,11 +192,17 @@ func (mc *MetricsFetcher) memory(mem raw.Memory) Memory {
 		usage = mem.RSS + mem.SwapUsage - mem.FuzzUsage
 	}
 
+	usagePercent := float64(0)
+	if memLimits > 0 {
+		usagePercent = 100 * float64(usage) / float64(memLimits)
+	}
+
 	return Memory{
 		MemLimitBytes:   memLimits,
 		CacheUsageBytes: mem.Cache,
 		RSSUsageBytes:   mem.RSS,
 		UsageBytes:      usage,
+		UsagePercent:    usagePercent,
 	}
 }
 

--- a/src/biz/metrics_test.go
+++ b/src/biz/metrics_test.go
@@ -125,6 +125,9 @@ func TestMemory(t *testing.T) {
 			"reported usage %v should be >= 60MB (%v)", mem.UsageBytes, expectedUsage)
 		assert.Truef(t, mem.RSSUsageBytes >= expectedUsage,
 			"reported RSS %v should be >= 60MB (%v)", mem.RSSUsageBytes, expectedUsage)
+		expectedPercent := float64(expectedUsage) * 100 / memLimit
+		assert.Truef(t, mem.UsagePercent >= expectedPercent,
+			"reported Usage Percent %v should be >= %v", mem.RSSUsageBytes, expectedPercent)
 		// todo: test cachebytes against a fixed value
 		assert.True(t, mem.CacheUsageBytes > 0, "reported cache bytes %v should not be zero")
 

--- a/src/nri/metrics.go
+++ b/src/nri/metrics.go
@@ -24,6 +24,7 @@ var (
 	metricMemoryCacheBytes        = metricFunc("memoryCacheBytes", metric.GAUGE)
 	metricMemoryResidentSizeBytes = metricFunc("memoryResidentSizeBytes", metric.GAUGE)
 	metricMemorySizeLimitBytes    = metricFunc("memorySizeLimitBytes", metric.GAUGE)
+	metricMemoryUsageLimitPercent = metricFunc("memoryUsageLimitPercent", metric.GAUGE)
 	metricIOReadCountPerSecond    = metricFunc("ioReadCountPerSecond", metric.RATE)
 	metricIOWriteCountPerSecond   = metricFunc("ioWriteCountPerSecond", metric.RATE)
 	metricIOReadBytesPerSecond    = metricFunc("ioReadBytesPerSecond", metric.RATE)

--- a/src/nri/sampler.go
+++ b/src/nri/sampler.go
@@ -152,12 +152,18 @@ func labels(container types.Container) []entry {
 }
 
 func memory(mem *biz.Memory) []entry {
-	return []entry{
+	metrics := []entry{
 		metricMemoryCacheBytes(mem.CacheUsageBytes),
 		metricMemoryUsageBytes(mem.UsageBytes),
 		metricMemoryResidentSizeBytes(mem.RSSUsageBytes),
-		metricMemorySizeLimitBytes(mem.MemLimitBytes),
 	}
+	if mem.MemLimitBytes > 0 {
+		metrics = append(metrics,
+			metricMemorySizeLimitBytes(mem.MemLimitBytes),
+			metricMemoryUsageLimitPercent(mem.UsagePercent),
+		)
+	}
+	return metrics
 }
 
 func pids(pids *biz.Pids) []entry {


### PR DESCRIPTION
Added metric `memoryUsageLimitPercent` that reports the usage of the container memory as
  a percentage of the limit. If there is no limit defined, this metric is not reported.

Metric `memorySizeLimitBytes` is not reported anymore when there is no such limit
  (before it was reported as `0`)