### PR TITLE
Fix and simplify the condition to skip non-running containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* Fixed bug in detection of non-running container in ECS environments.
+
 ## 1.3.0 (20-04-?)
 * Added support for cgroup driver 'systemd'.
 

--- a/src/nri/sampler.go
+++ b/src/nri/sampler.go
@@ -101,7 +101,8 @@ func (cs *ContainerSampler) SampleAll(ctx context.Context, i *integration.Integr
 		// i.e. Docker uses `state = running` and ECS uses `status = RUNNING`.
 		// If State is empty, we check by status up.
 		if strings.ToLower(container.State) != "running" &&
-			!(container.State == "" && strings.HasPrefix(strings.ToLower(container.Status), "up")) {
+			strings.ToLower(container.Status) != "running" &&
+			!strings.HasPrefix(strings.ToLower(container.Status), "up") {
 			log.Debug("Skipped not running container: %s.", container.ID)
 			continue
 		}


### PR DESCRIPTION
The logic in this conditional was broken for Fargate containers, as the check on `container.Status != "running"` was removed.

I took some time to simplify the `if`, as it was very difficult to read. The logic to identify containers that are not running is:

* their **state** isn't `running` (case insensitive, covers classic cgroups containers)
* their **status** isn't `running` (case insensitive, covers ECS containers)
* their **status** doesn't start with `up` (case insensitive, covers cgroups container with the systemd driver)

There's no need to check if `state` or `status` are or not empty.