### PR TITLE
Embed fargate data in container samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.3 (2020-11-12)
+### Changed
+* Add metadata to samples from Fargate (#50)
+
 ## 1.3.2 (2020-07-17)
 ### Changed
 * Set the correct integration Version

--- a/src/nri/sampler.go
+++ b/src/nri/sampler.go
@@ -158,12 +158,16 @@ var labelRename = map[string]string{
 	"com.amazonaws.ecs.task-arn":                "ecsTaskArn",
 	"com.amazonaws.ecs.task-definition-family":  "ecsTaskDefinitionFamily",
 	"com.amazonaws.ecs.task-definition-version": "ecsTaskDefinitionVersion",
+
+	// com.newrelic.nri-docker.* labels are created by aws.processFargateLabels containing fargate info
+	"com.newrelic.nri-docker.launch-type": "ecsLaunchType",
+	"com.newrelic.nri-docker.cluster-arn": "ecsClusterArn",
+	"com.newrelic.nri-docker.aws-region":  "awsRegion",
 }
 
 func labels(container types.Container) []entry {
 	metrics := make([]entry, 0, len(container.Labels))
 	for key, val := range container.Labels {
-
 		if newName, ok := labelRename[key]; ok {
 			metrics = append(metrics, entry{
 				Name:  newName,
@@ -178,6 +182,7 @@ func labels(container types.Container) []entry {
 			Type:  metric.ATTRIBUTE,
 		})
 	}
+
 	return metrics
 }
 

--- a/src/raw/aws/fargate_inspector_test.go
+++ b/src/raw/aws/fargate_inspector_test.go
@@ -1,0 +1,26 @@
+package aws
+
+import "testing"
+
+func TestProcessFargateLabels(t *testing.T) {
+	labels := processFargateLabels(map[string]string{
+		"com.amazonaws.ecs.cluster":                 "arn:aws:ecs:my-region:100000000000:cluster/the-cluster-name",
+		"com.amazonaws.ecs.task-arn":                "arn:aws:ecs:my-region:100000000000:task/the-cluster-name/f05a5672397746638bc201a252c5bb75",
+		"com.amazonaws.ecs.task-definition-family":  "the-task-definition-family",
+		"com.amazonaws.ecs.task-definition-version": "the-task-definition-version",
+	})
+
+	expected := map[string]string{
+		"com.amazonaws.ecs.cluster":           "the-cluster-name",
+		"com.amazonaws.ecs.task-arn":          "arn:aws:ecs:my-region:100000000000:task/the-cluster-name/f05a5672397746638bc201a252c5bb75",
+		"com.newrelic.nri-docker.cluster-arn": "arn:aws:ecs:my-region:100000000000:cluster/the-cluster-name",
+		"com.newrelic.nri-docker.aws-region":  "my-region",
+		"com.newrelic.nri-docker.launch-type": "fargate", // Set to fargate as 'com.amazonaws.ecs.cluster' is an arn
+	}
+
+	for eK, eV := range expected {
+		if v := labels[eK]; v != eV {
+			t.Fatalf("expected label %s to be '%s', found '%s' instead", eK, eV, v)
+		}
+	}
+}

--- a/src/raw/aws/fargate_metadata.go
+++ b/src/raw/aws/fargate_metadata.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/newrelic/infra-integrations-sdk/log"
@@ -157,20 +156,4 @@ func MetadataV3BaseURL() (*url.URL, error) {
 		return nil, fmt.Errorf("could not parse Metadata V3 API URL (%s): %s", baseURL, err)
 	}
 	return parsedURL, nil
-}
-
-// RegionFromTask returns the aws region from the task ARN.
-// Example of task ARN: arn:aws:ecs:us-west-2:xxxxxxxx:task/ecs-local-cluster/37e873f6-37b4-42a7-af47-eac7275c6152
-func RegionFromTask(taskARN string) string {
-	_, arnPrefix := ResourceNameAndARNBase(taskARN)
-	return strings.Split(arnPrefix, ":")[3]
-}
-
-// ResourceNameAndARNBase explodes a resource ARN and returns the resource's name and the base ARN prefix for the
-// account and region of the original resource.
-func ResourceNameAndARNBase(resourceARN string) (resourceName string, arnPrefix string) {
-	arnPrefixAndType := resourceARN[:strings.Index(resourceARN, "/")-1]
-	arnPrefix = arnPrefixAndType[:strings.LastIndex(arnPrefixAndType, ":")]
-	resourceName = resourceARN[strings.Index(resourceARN, "/")+1:]
-	return resourceName, arnPrefix
 }

--- a/src/raw/aws/fargate_metadata.go
+++ b/src/raw/aws/fargate_metadata.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/newrelic/infra-integrations-sdk/log"
@@ -156,4 +157,20 @@ func MetadataV3BaseURL() (*url.URL, error) {
 		return nil, fmt.Errorf("could not parse Metadata V3 API URL (%s): %s", baseURL, err)
 	}
 	return parsedURL, nil
+}
+
+// RegionFromTask returns the aws region from the task ARN.
+// Example of task ARN: arn:aws:ecs:us-west-2:xxxxxxxx:task/ecs-local-cluster/37e873f6-37b4-42a7-af47-eac7275c6152
+func RegionFromTask(taskARN string) string {
+	_, arnPrefix := ResourceNameAndARNBase(taskARN)
+	return strings.Split(arnPrefix, ":")[3]
+}
+
+// ResourceNameAndARNBase explodes a resource ARN and returns the resource's name and the base ARN prefix for the
+// account and region of the original resource.
+func ResourceNameAndARNBase(resourceARN string) (resourceName string, arnPrefix string) {
+	arnPrefixAndType := resourceARN[:strings.Index(resourceARN, "/")-1]
+	arnPrefix = arnPrefixAndType[:strings.LastIndex(arnPrefixAndType, ":")]
+	resourceName = resourceARN[strings.Index(resourceARN, "/")+1:]
+	return resourceName, arnPrefix
 }


### PR DESCRIPTION
Fixes #49 

When running in transparent mode, as is the case in Fargate, the agent will not decorate metrics with Fargate metadata such as `awsRegion`, `ecsLaunchType`, and `ecsClusterName`. Breaking queries that use such attributes.

In this PR we fix this by pulling such metadata from the docker container labels that Fargate adds to the container information, by parsing the task arn and the cluster name. This is the same way in which https://github.com/newrelic/nri-ecs obtains this information. `RegionFromTask` and `ResourceNameAndARNBase` have been pulled from said repo as well.

### TODO:

- [x] Unit testing

### Manual testing checklist

- [x] Integration works as expected in Fargate mode, when `FARGATE` and `NRIA_IS_FORWARD_ONLY` are set
- [x] Integration works in as expected in EC2 mode
[json-comparison.tar.gz](https://github.com/newrelic/nri-docker/files/5517495/json-comparison.tar.gz)
