### PR TITLE
Add feature to stop reporting exited containers after a certain TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+* The integration by default does not report exited containers that are older than 24 hours.
+  This value can be configured using the `ExitedContainersTTL` argument using any value that 
+  can be parsed into a `time.Duration`, i.e. `1s`, `1m`, `1h`.
+  To replicate the old behavior of the integration, set this argument to `0` (zero).
+
 ## 1.3.3 (2020-11-12)
 ### Changed
 * Add metadata to samples from Fargate (#50)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 * nri-docker will no longer report containers that have been stopped for more than 24 hours.
-  This value can be configured using the `ExitedContainersTTL` argument using any value that 
-  can be parsed into a `time.Duration`, i.e. `1s`, `1m`, `1h`.
-  To replicate the old behavior of the integration, set this argument to `0` (zero).
+  This value can be configured using the `EXITED_CONTAINERS_TTL` environment variable using 
+  any value that can be parsed into a `time.Duration`, i.e. `1s`, `1m`, `1h`.
+  To replicate the old behavior of the integration, set this environment variable to `0` (zero).
 
 ## 1.3.3 (2020-11-12)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.3.4 (2020-11-19)
+## 1.4.0 (2020-11-19)
 
 ### Changed
 * nri-docker will no longer report containers that have been stopped for more than 24 hours.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## 1.3.4 (2020-11-19)
 
 ### Changed
 * nri-docker will no longer report containers that have been stopped for more than 24 hours.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Changed
-* The integration by default does not report exited containers that are older than 24 hours.
+* nri-docker will no longer report containers that have been stopped for more than 24 hours.
   This value can be configured using the `ExitedContainersTTL` argument using any value that 
   can be parsed into a `time.Duration`, i.e. `1s`, `1m`, `1h`.
   To replicate the old behavior of the integration, set this argument to `0` (zero).

--- a/src/biz/metrics.go
+++ b/src/biz/metrics.go
@@ -118,7 +118,7 @@ func (mc *MetricsFetcher) Process(containerID string) (Sample, error) {
 		log.Debug("invalid container %s JSON: missing State", containerID)
 	}
 
-	if mc.exitedContainerTTL != 0 && strings.ToLower(json.State.Status) == "exited" {
+	if mc.exitedContainerTTL != 0 && json.State != nil && strings.ToLower(json.State.Status) == "exited" {
 		exitTimestamp, err := time.Parse(time.RFC3339Nano, json.State.FinishedAt)
 		if err != nil {
 			return metrics, fmt.Errorf("invalid finished_at timestamp for exited container %s: %s (%v)",

--- a/src/biz/metrics.go
+++ b/src/biz/metrics.go
@@ -70,9 +70,9 @@ type Processer interface {
 // MetricsFetcher fetches the container system-level metrics from different sources and processes it to export
 // metrics with business-value
 type MetricsFetcher struct {
-	store     persist.Storer
-	fetcher   raw.Fetcher
-	inspector Inspector
+	store              persist.Storer
+	fetcher            raw.Fetcher
+	inspector          Inspector
 	exitedContainerTTL time.Duration
 }
 
@@ -84,9 +84,9 @@ type Inspector interface {
 // NewProcessor creates a MetricsFetcher from implementations of its required components
 func NewProcessor(store persist.Storer, fetcher raw.Fetcher, inspector Inspector, exitedContainerTTL time.Duration) *MetricsFetcher {
 	return &MetricsFetcher{
-		store:     store,
-		fetcher:   fetcher,
-		inspector: inspector,
+		store:              store,
+		fetcher:            fetcher,
+		inspector:          inspector,
 		exitedContainerTTL: exitedContainerTTL,
 	}
 }
@@ -125,7 +125,6 @@ func (mc *MetricsFetcher) Process(containerID string) (Sample, error) {
 			return metrics, ErrExitedContainerExpired{"container exited after TTL, skipping"}
 		}
 	}
-
 
 	rawMetrics, err := mc.fetcher.Fetch(json)
 	if err != nil {

--- a/src/biz/metrics.go
+++ b/src/biz/metrics.go
@@ -127,7 +127,7 @@ func (mc *MetricsFetcher) Process(containerID string) (Sample, error) {
 				err,
 			)
 		}
-		if time.Now().After(exitTimestamp.Add(mc.exitedContainerTTL)) {
+		if time.Since(exitTimestamp) > mc.exitedContainerTTL {
 			return metrics, ErrExitedContainerExpired{
 				fmt.Sprintf("container %s exited after TTL (%v), skipping", containerID, mc.exitedContainerTTL),
 			}

--- a/src/biz/metrics.go
+++ b/src/biz/metrics.go
@@ -4,8 +4,10 @@ package biz
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -71,6 +73,7 @@ type MetricsFetcher struct {
 	store     persist.Storer
 	fetcher   raw.Fetcher
 	inspector Inspector
+	exitedContainerTTL time.Duration
 }
 
 // Inspector is the abstraction of the only method that we require from the docker go client
@@ -79,12 +82,21 @@ type Inspector interface {
 }
 
 // NewProcessor creates a MetricsFetcher from implementations of its required components
-func NewProcessor(store persist.Storer, fetcher raw.Fetcher, inspector Inspector) *MetricsFetcher {
+func NewProcessor(store persist.Storer, fetcher raw.Fetcher, inspector Inspector, exitedContainerTTL time.Duration) *MetricsFetcher {
 	return &MetricsFetcher{
 		store:     store,
 		fetcher:   fetcher,
 		inspector: inspector,
+		exitedContainerTTL: exitedContainerTTL,
 	}
+}
+
+type ErrExitedContainerExpired struct {
+	s string
+}
+
+func (e ErrExitedContainerExpired) Error() string {
+	return e.s
 }
 
 // Process returns a metrics Sample of the container with the given ID
@@ -95,14 +107,25 @@ func (mc *MetricsFetcher) Process(containerID string) (Sample, error) {
 	if err != nil {
 		return metrics, err
 	}
-	// TODO: move logic to skip container without State to Docker specific code.
 	if json.ContainerJSONBase == nil {
 		return metrics, errors.New("empty container inspect result")
 	}
 
+	// TODO: move logic to skip container without State to Docker specific code.
 	if json.State == nil {
 		log.Debug("invalid container %s JSON: missing State", containerID)
 	}
+
+	if mc.exitedContainerTTL != 0 && strings.ToLower(json.State.Status) == "exited" {
+		exitTimestamp, err := time.Parse(time.RFC3339Nano, json.State.FinishedAt)
+		if err != nil {
+			return metrics, fmt.Errorf("invalid finished_at timestamp for exited container: %v", err)
+		}
+		if time.Now().After(exitTimestamp.Add(mc.exitedContainerTTL)) {
+			return metrics, ErrExitedContainerExpired{"container exited after TTL, skipping"}
+		}
+	}
+
 
 	rawMetrics, err := mc.fetcher.Fetch(json)
 	if err != nil {

--- a/src/biz/metrics.go
+++ b/src/biz/metrics.go
@@ -91,6 +91,8 @@ func NewProcessor(store persist.Storer, fetcher raw.Fetcher, inspector Inspector
 	}
 }
 
+// ErrExitedContainerExpired is the error type used when exited containers have exceed the TTL that would allow the
+// integration to keep reporting them.
 type ErrExitedContainerExpired struct {
 	s string
 }

--- a/src/biz/metrics.go
+++ b/src/biz/metrics.go
@@ -121,10 +121,16 @@ func (mc *MetricsFetcher) Process(containerID string) (Sample, error) {
 	if mc.exitedContainerTTL != 0 && strings.ToLower(json.State.Status) == "exited" {
 		exitTimestamp, err := time.Parse(time.RFC3339Nano, json.State.FinishedAt)
 		if err != nil {
-			return metrics, fmt.Errorf("invalid finished_at timestamp for exited container: %v", err)
+			return metrics, fmt.Errorf("invalid finished_at timestamp for exited container %s: %s (%v)",
+				containerID,
+				json.State.FinishedAt,
+				err,
+			)
 		}
 		if time.Now().After(exitTimestamp.Add(mc.exitedContainerTTL)) {
-			return metrics, ErrExitedContainerExpired{"container exited after TTL, skipping"}
+			return metrics, ErrExitedContainerExpired{
+				fmt.Sprintf("container %s exited after TTL (%v), skipping", containerID, mc.exitedContainerTTL),
+			}
 		}
 	}
 

--- a/src/biz/metrics_aws_test.go
+++ b/src/biz/metrics_aws_test.go
@@ -30,11 +30,7 @@ func TestFargateMetrics(t *testing.T) {
 	inspector, err := aws.NewFargateInspector(baseURL)
 	require.NoError(t, err)
 
-	metrics := NewProcessor(
-		persist.NewInMemoryStore(),
-		fetcher,
-		inspector,
-	)
+	metrics := NewProcessor(persist.NewInMemoryStore(), fetcher, inspector, 0)
 	samples, err := metrics.Process(fargateContainerID)
 	require.NoError(t, err)
 

--- a/src/biz/metrics_test.go
+++ b/src/biz/metrics_test.go
@@ -180,7 +180,7 @@ func stress(t *testing.T, args ...string) (containerID string, closeFunc func())
 
 func TestExitedContainersWithTTL(t *testing.T) {
 	// GIVEN a container consuming a lot of CPU
-	containerID, dockerRM := stress(t, "stress-ng", "-c", "4", "-l 100", "-t", "1s")
+	containerID, dockerRM := stress(t, "stress-ng", "-c", "0", "-l", "0", "--vm", "1", "--vm-bytes", "60M", "-t", "1s")
 	defer dockerRM()
 
 	// WHEN its metrics are sampled and processed
@@ -201,7 +201,7 @@ func TestExitedContainersWithTTL(t *testing.T) {
 
 func TestExitedContainersWithoutTTL(t *testing.T) {
 	// GIVEN a container consuming a lot of CPU
-	containerID, dockerRM := stress(t, "stress-ng", "-c", "4", "-l 100", "-t", "1s")
+	containerID, dockerRM := stress(t, "stress-ng", "-c", "0", "-l", "0", "--vm", "1", "--vm-bytes", "60M", "-t", "1s")
 	defer dockerRM()
 
 	// WHEN its metrics are sampled and processed

--- a/src/biz/metrics_test.go
+++ b/src/biz/metrics_test.go
@@ -215,7 +215,7 @@ func TestExitedContainersWithoutTTL(t *testing.T) {
 
 	test.Eventually(t, eventuallyTimeout, func(t require.TestingT) {
 		sample, err := metrics.Process(containerID)
-		require.NoError(t, err)
+		require.Error(t, err)
 		assert.Empty(t, sample)
 	})
 }

--- a/src/biz/metrics_test.go
+++ b/src/biz/metrics_test.go
@@ -214,8 +214,8 @@ func TestExitedContainersWithoutTTL(t *testing.T) {
 	metrics := NewProcessor(persist.NewInMemoryStore(), cgroupFetcher, docker, 0)
 
 	test.Eventually(t, eventuallyTimeout, func(t require.TestingT) {
-		samples, err := metrics.Process(containerID)
+		sample, err := metrics.Process(containerID)
 		require.NoError(t, err)
-		assert.Len(t, samples, 1)
+		assert.Empty(t, sample)
 	})
 }

--- a/src/biz/metrics_test.go
+++ b/src/biz/metrics_test.go
@@ -190,7 +190,7 @@ func TestExitedContainersWithTTL(t *testing.T) {
 	cgroupFetcher, err := raw.NewCgroupsFetcher("/", "cgroupfs", "")
 	require.NoError(t, err)
 
-	metrics := NewProcessor(persist.NewInMemoryStore(), cgroupFetcher, docker, 1 * time.Second)
+	metrics := NewProcessor(persist.NewInMemoryStore(), cgroupFetcher, docker, 1*time.Second)
 
 	test.Eventually(t, eventuallyTimeout, func(t require.TestingT) {
 		samples, err := metrics.Process(containerID)

--- a/src/biz/metrics_test.go
+++ b/src/biz/metrics_test.go
@@ -179,11 +179,9 @@ func stress(t *testing.T, args ...string) (containerID string, closeFunc func())
 }
 
 func TestExitedContainersWithTTL(t *testing.T) {
-	// GIVEN a container consuming a lot of CPU
 	containerID, dockerRM := stress(t, "stress-ng", "-c", "0", "-l", "0", "--vm", "1", "--vm-bytes", "60M", "-t", "1s")
 	defer dockerRM()
 
-	// WHEN its metrics are sampled and processed
 	docker := newDocker(t)
 	defer docker.Close()
 
@@ -200,11 +198,9 @@ func TestExitedContainersWithTTL(t *testing.T) {
 }
 
 func TestExitedContainersWithoutTTL(t *testing.T) {
-	// GIVEN a container consuming a lot of CPU
 	containerID, dockerRM := stress(t, "stress-ng", "-c", "0", "-l", "0", "--vm", "1", "--vm-bytes", "60M", "-t", "1s")
 	defer dockerRM()
 
-	// WHEN its metrics are sampled and processed
 	docker := newDocker(t)
 	defer docker.Close()
 

--- a/src/biz/metrics_test.go
+++ b/src/biz/metrics_test.go
@@ -39,10 +39,7 @@ func TestHighCPU(t *testing.T) {
 	cgroupFetcher, err := raw.NewCgroupsFetcher("/", "cgroupfs", "")
 	require.NoError(t, err)
 
-	metrics := NewProcessor(
-		persist.NewInMemoryStore(),
-		cgroupFetcher,
-		docker)
+	metrics := NewProcessor(persist.NewInMemoryStore(), cgroupFetcher, docker, 0)
 	sample, err := metrics.Process(containerID)
 	require.NoError(t, err)
 
@@ -85,10 +82,7 @@ func TestLowCPU(t *testing.T) {
 	cgroupFetcher, err := raw.NewCgroupsFetcher("/", "cgroupfs", "")
 	require.NoError(t, err)
 
-	metrics := NewProcessor(
-		persist.NewInMemoryStore(),
-		cgroupFetcher,
-		docker)
+	metrics := NewProcessor(persist.NewInMemoryStore(), cgroupFetcher, docker, 0)
 	sample, err := metrics.Process(containerID)
 	require.NoError(t, err)
 
@@ -122,10 +116,7 @@ func TestMemory(t *testing.T) {
 	cgroupFetcher, err := raw.NewCgroupsFetcher("/", "cgroupfs", "")
 	require.NoError(t, err)
 
-	metrics := NewProcessor(
-		persist.NewInMemoryStore(),
-		cgroupFetcher,
-		docker)
+	metrics := NewProcessor(persist.NewInMemoryStore(), cgroupFetcher, docker, 0)
 	// Then the Memory metrics are reported according to the usage and limits
 	test.Eventually(t, eventuallyTimeout, func(t require.TestingT) {
 		sample, err := metrics.Process(containerID)

--- a/src/docker.go
+++ b/src/docker.go
@@ -21,7 +21,7 @@ type argumentList struct {
 	HostRoot            string `default:"" help:"If the integration is running from a container, the mounted folder pointing to the host root folder"`
 	CgroupPath          string `default:"" help:"Optional. The path where cgroup is mounted."`
 	Fargate             bool   `default:"false" help:"Enables Fargate container metrics fetching. If enabled no metrics are collected from cgroups or Docker. Defaults to false"`
-	ExitedContainersTTL string `default:"24h" help:"Enables to integration to stop reporting Exited contaienrs that are older than the set TTL. Possible values are time-strings: 1s, 1m, 1h"`
+	ExitedContainersTTL string `default:"24h" help:"Enables to integration to stop reporting Exited containers that are older than the set TTL. Possible values are time-strings: 1s, 1m, 1h"`
 	CgroupDriver        string `default:"" help:"Optional. Specify the cgroup driver."`
 	DockerClientVersion string `default:"1.24" help:"Optional. Specify the version of the docker client. Used for compatibility."`
 }

--- a/src/docker.go
+++ b/src/docker.go
@@ -21,7 +21,7 @@ type argumentList struct {
 	HostRoot            string `default:"" help:"If the integration is running from a container, the mounted folder pointing to the host root folder"`
 	CgroupPath          string `default:"" help:"Optional. The path where cgroup is mounted."`
 	Fargate             bool   `default:"false" help:"Enables Fargate container metrics fetching. If enabled no metrics are collected from cgroups or Docker. Defaults to false"`
-	ExitedContainersTTL string `default:"" help:"Enables to integration to stop reporting Exited contaienrs that are older than the set TTL. Possible values are time-strings: 1s, 1m, 1h, 1d"`
+	ExitedContainersTTL string `default:"24h" help:"Enables to integration to stop reporting Exited contaienrs that are older than the set TTL. Possible values are time-strings: 1s, 1m, 1h"`
 	CgroupDriver        string `default:"" help:"Optional. Specify the cgroup driver."`
 	DockerClientVersion string `default:"1.24" help:"Optional. Specify the version of the docker client. Used for compatibility."`
 }

--- a/src/docker.go
+++ b/src/docker.go
@@ -28,7 +28,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.docker"
-	integrationVersion = "1.3.3"
+	integrationVersion = "1.3.4"
 )
 
 var (

--- a/src/docker.go
+++ b/src/docker.go
@@ -28,7 +28,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.docker"
-	integrationVersion = "1.3.4"
+	integrationVersion = "1.4.0"
 )
 
 var (

--- a/src/nri/sampler.go
+++ b/src/nri/sampler.go
@@ -72,11 +72,11 @@ func (cs *ContainerSampler) SampleAll(ctx context.Context, i *integration.Integr
 	for _, container := range containers {
 		metrics, err := cs.metrics.Process(container.ID)
 		if err != nil {
-			log.Error("error fetching metrics for container %v: %v", container.ID, err)
 			if _, ok := err.(*biz.ErrExitedContainerExpired); ok {
-				log.Debug("skipping exited container older than TTL")
+				log.Debug(err.Error())
 				continue
 			}
+			log.Error("error fetching metrics for container %v: %v", container.ID, err)
 		}
 
 		// Creating entity and populating metrics

--- a/src/nri/sampler.go
+++ b/src/nri/sampler.go
@@ -36,10 +36,8 @@ type DockerClient interface {
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
 }
 
-// NewSampler returns a ContainerSampler instance. The hostRoot argument is used only if the integration is
-// executed inside a container, and must point to the shared folder that allows accessing to the host root
-// folder (usually /host)
-func NewSampler(fetcher raw.Fetcher, docker DockerClient) (*ContainerSampler, error) {
+// NewSampler returns a ContainerSampler instance.
+func NewSampler(fetcher raw.Fetcher, docker DockerClient, exitedContainerTTL time.Duration) (*ContainerSampler, error) {
 	// SDK Storer to keep metric values between executions (e.g. for rates and deltas)
 	store, err := persist.NewFileStore( // TODO: make the following options configurable
 		persist.DefaultPath("container_cpus"),
@@ -50,7 +48,7 @@ func NewSampler(fetcher raw.Fetcher, docker DockerClient) (*ContainerSampler, er
 	}
 
 	return &ContainerSampler{
-		metrics: biz.NewProcessor(store, fetcher, docker),
+		metrics: biz.NewProcessor(store, fetcher, docker, exitedContainerTTL),
 		docker:  docker,
 		store:   store,
 	}, nil
@@ -72,6 +70,15 @@ func (cs *ContainerSampler) SampleAll(ctx context.Context, i *integration.Integr
 	}
 
 	for _, container := range containers {
+		metrics, err := cs.metrics.Process(container.ID)
+		if err != nil {
+			log.Error("error fetching metrics for container %v: %v", container.ID, err)
+			if _, ok := err.(*biz.ErrExitedContainerExpired); ok {
+				log.Debug("skipping exited container older than TTL")
+				continue
+			}
+		}
+
 		// Creating entity and populating metrics
 		entity, err := i.Entity(container.ID, "docker")
 		if err != nil {
@@ -95,8 +102,8 @@ func (cs *ContainerSampler) SampleAll(ctx context.Context, i *integration.Integr
 		populate(ms, labels(container))
 
 		// TODO: this *needs* to be refactored into the call to ContainerList, because different
-		// systems might represent running container in a slightly different way. This can be tricky
-		// because for Docker containers we're relyng on the capabilities of the official Docker client.
+		// systems might represent running containers in a slightly different way. This can be tricky
+		// because for Docker containers we're relying on the capabilities of the official Docker client.
 		// Possibly wrapping the Docker client with another type is a good solution.
 		// i.e. Docker uses `state = running` and ECS uses `status = RUNNING`.
 		// If State is empty, we check by status up.
@@ -108,11 +115,6 @@ func (cs *ContainerSampler) SampleAll(ctx context.Context, i *integration.Integr
 		}
 
 		// populating metrics that only apply to running containers
-		metrics, err := cs.metrics.Process(container.ID)
-		if err != nil {
-			log.Error("error fetching metrics for container %v: %v", container.ID, err)
-			continue
-		}
 		populate(ms, misc(&metrics))
 		populate(ms, cpu(&metrics.CPU))
 		populate(ms, memory(&metrics.Memory))

--- a/src/nri/sampler_test.go
+++ b/src/nri/sampler_test.go
@@ -91,7 +91,7 @@ func TestECSLabelRename(t *testing.T) {
 	mStore.On("Save").Return(nil)
 
 	sampler := ContainerSampler{
-		metrics: biz.NewProcessor(mStore, nil, mocker),
+		metrics: biz.NewProcessor(mStore, nil, mocker, 0),
 		docker:  mocker,
 		store:   mStore,
 	}


### PR DESCRIPTION
The Docker daemon might keep exited containers indefinitely if they're not properly removed by whoever started them: either by running such containers with `--rm`, by removing the container manually after its execution or by running `docker container prune`. 

To avoid spamming New Relic with this data this PR changes the behavior of this integration to avoid reporting containers that are exited for more than 24 hours ago. This value is configurable through the `ExitedContainersTTL` argument.

If some users want to keep the old behavior, they can set it to `0`. 