### PR TITLE
fix: add correct config to the bundle

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -19,7 +19,7 @@ archives:
       - nri-nix
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Version }}_{{ .Arch }}_dirty"
     files:
-      - docker-config.yml.sample
+      - docker-config.yml
       - docker-definition.yml
     format: tar.gz
 

--- a/build/nix/fix_archives.sh
+++ b/build/nix/fix_archives.sh
@@ -24,7 +24,7 @@ find dist -regex ".*_dirty\.tar.gz" | while read tarball_dirty; do
   echo "===> Move files inside ${tarball}"
   mv ${TARBALL_CONTENT_PATH}/nri-${INTEGRATION} "${TARBALL_CONTENT_PATH}/var/db/newrelic-infra/newrelic-integrations/bin/"
   mv ${TARBALL_CONTENT_PATH}/${INTEGRATION}-definition.yml ${TARBALL_CONTENT_PATH}/var/db/newrelic-infra/newrelic-integrations/
-  mv ${TARBALL_CONTENT_PATH}/${INTEGRATION}-config.yml.sample ${TARBALL_CONTENT_PATH}/etc/newrelic-infra/integrations.d/
+  mv ${TARBALL_CONTENT_PATH}/${INTEGRATION}-config.yml ${TARBALL_CONTENT_PATH}/etc/newrelic-infra/integrations.d/
 
   echo "===> Creating tarball ${TARBALL_CLEAN}"
   cd ${TARBALL_CONTENT_PATH}


### PR DESCRIPTION
During the pipeline migration the config file added to the bundle was not the expected by the agent to be automatically activated. This Pr fixes that.