### PR TITLE
feat(fargate): adding networking info

### DIFF
--- a/src/biz/testdata/v4_task_container_stats_response.json
+++ b/src/biz/testdata/v4_task_container_stats_response.json
@@ -1,0 +1,272 @@
+{
+  "01999f2e5c6cf4df3873f28950e6278813408f281c54778efec860d0caad4854": {
+    "read": "2020-10-02T00:51:32.51467703Z",
+    "preread": "2020-10-02T00:51:31.50860463Z",
+    "pids_stats": {
+      "current": 1
+    },
+    "blkio_stats": {
+      "io_service_bytes_recursive": [
+
+      ],
+      "io_serviced_recursive": [
+
+      ],
+      "io_queue_recursive": [
+
+      ],
+      "io_service_time_recursive": [
+
+      ],
+      "io_wait_time_recursive": [
+
+      ],
+      "io_merged_recursive": [
+
+      ],
+      "io_time_recursive": [
+
+      ],
+      "sectors_recursive": [
+
+      ]
+    },
+    "num_procs": 0,
+    "storage_stats": {
+
+    },
+    "cpu_stats": {
+      "cpu_usage": {
+        "total_usage": 177232665,
+        "percpu_usage": [
+          13376224,
+          163856441
+        ],
+        "usage_in_kernelmode": 0,
+        "usage_in_usermode": 160000000
+      },
+      "system_cpu_usage": 13977820000000,
+      "online_cpus": 2,
+      "throttling_data": {
+        "periods": 0,
+        "throttled_periods": 0,
+        "throttled_time": 0
+      }
+    },
+    "precpu_stats": {
+      "cpu_usage": {
+        "total_usage": 177232665,
+        "percpu_usage": [
+          13376224,
+          163856441
+        ],
+        "usage_in_kernelmode": 0,
+        "usage_in_usermode": 160000000
+      },
+      "system_cpu_usage": 13975800000000,
+      "online_cpus": 2,
+      "throttling_data": {
+        "periods": 0,
+        "throttled_periods": 0,
+        "throttled_time": 0
+      }
+    },
+    "memory_stats": {
+      "usage": 532480,
+      "max_usage": 6279168,
+      "stats": {
+        "active_anon": 40960,
+        "active_file": 0,
+        "cache": 0,
+        "dirty": 0,
+        "hierarchical_memory_limit": 9223372036854771712,
+        "hierarchical_memsw_limit": 9223372036854771712,
+        "inactive_anon": 0,
+        "inactive_file": 0,
+        "mapped_file": 0,
+        "pgfault": 2033,
+        "pgmajfault": 0,
+        "pgpgin": 1734,
+        "pgpgout": 1724,
+        "rss": 40960,
+        "rss_huge": 0,
+        "total_active_anon": 40960,
+        "total_active_file": 0,
+        "total_cache": 0,
+        "total_dirty": 0,
+        "total_inactive_anon": 0,
+        "total_inactive_file": 0,
+        "total_mapped_file": 0,
+        "total_pgfault": 2033,
+        "total_pgmajfault": 0,
+        "total_pgpgin": 1734,
+        "total_pgpgout": 1724,
+        "total_rss": 40960,
+        "total_rss_huge": 0,
+        "total_unevictable": 0,
+        "total_writeback": 0,
+        "unevictable": 0,
+        "writeback": 0
+      },
+      "limit": 4073377792
+    },
+    "name": "/ecs-curltest-26-internalecspause-a6bcc3dbadfacfe85300",
+    "id": "01999f2e5c6cf4df3873f28950e6278813408f281c54778efec860d0caad4854",
+    "networks": {
+      "eth0": {
+        "rx_bytes": 84,
+        "rx_packets": 2,
+        "rx_errors": 0,
+        "rx_dropped": 0,
+        "tx_bytes": 84,
+        "tx_packets": 2,
+        "tx_errors": 0,
+        "tx_dropped": 0
+      }
+    },
+    "network_rate_stats": {
+      "rx_bytes_per_sec": 0,
+      "tx_bytes_per_sec": 0
+    }
+  },
+  "2bd0cbf916a2745ef9377277c33fd7e6582455d73feb0d22a15f421496d5f916": {
+    "read": "2020-10-02T00:51:32.512771349Z",
+    "preread": "2020-10-02T00:51:31.510597736Z",
+    "pids_stats": {
+      "current": 3
+    },
+    "blkio_stats": {
+      "io_service_bytes_recursive": [
+
+      ],
+      "io_serviced_recursive": [
+
+      ],
+      "io_queue_recursive": [
+
+      ],
+      "io_service_time_recursive": [
+
+      ],
+      "io_wait_time_recursive": [
+
+      ],
+      "io_merged_recursive": [
+
+      ],
+      "io_time_recursive": [
+
+      ],
+      "sectors_recursive": [
+
+      ]
+    },
+    "num_procs": 0,
+    "storage_stats": {
+
+    },
+    "cpu_stats": {
+      "cpu_usage": {
+        "total_usage": 379075681,
+        "percpu_usage": [
+          191355275,
+          187720406
+        ],
+        "usage_in_kernelmode": 60000000,
+        "usage_in_usermode": 310000000
+      },
+      "system_cpu_usage": 13977800000000,
+      "online_cpus": 2,
+      "throttling_data": {
+        "periods": 0,
+        "throttled_periods": 0,
+        "throttled_time": 0
+      }
+    },
+    "precpu_stats": {
+      "cpu_usage": {
+        "total_usage": 378825197,
+        "percpu_usage": [
+          191104791,
+          187720406
+        ],
+        "usage_in_kernelmode": 60000000,
+        "usage_in_usermode": 310000000
+      },
+      "system_cpu_usage": 13975800000000,
+      "online_cpus": 2,
+      "throttling_data": {
+        "periods": 0,
+        "throttled_periods": 0,
+        "throttled_time": 0
+      }
+    },
+    "memory_stats": {
+      "usage": 1814528,
+      "max_usage": 6299648,
+      "stats": {
+        "active_anon": 606208,
+        "active_file": 0,
+        "cache": 0,
+        "dirty": 0,
+        "hierarchical_memory_limit": 134217728,
+        "hierarchical_memsw_limit": 268435456,
+        "inactive_anon": 0,
+        "inactive_file": 0,
+        "mapped_file": 0,
+        "pgfault": 5377,
+        "pgmajfault": 0,
+        "pgpgin": 3613,
+        "pgpgout": 3465,
+        "rss": 606208,
+        "rss_huge": 0,
+        "total_active_anon": 606208,
+        "total_active_file": 0,
+        "total_cache": 0,
+        "total_dirty": 0,
+        "total_inactive_anon": 0,
+        "total_inactive_file": 0,
+        "total_mapped_file": 0,
+        "total_pgfault": 5377,
+        "total_pgmajfault": 0,
+        "total_pgpgin": 3613,
+        "total_pgpgout": 3465,
+        "total_rss": 606208,
+        "total_rss_huge": 0,
+        "total_unevictable": 0,
+        "total_writeback": 0,
+        "unevictable": 0,
+        "writeback": 0
+      },
+      "limit": 134217728
+    },
+    "name": "/ecs-curltest-26-curl-c2e5f6e0cf91b0bead01",
+    "id": "2bd0cbf916a2745ef9377277c33fd7e6582455d73feb0d22a15f421496d5f916",
+    "networks": {
+      "eth0": {
+        "rx_bytes": 84,
+        "rx_packets": 2,
+        "rx_errors": 0,
+        "rx_dropped": 0,
+        "tx_bytes": 84,
+        "tx_packets": 2,
+        "tx_errors": 0,
+        "tx_dropped": 0
+      },
+      "eth1": {
+        "rx_bytes": 0,
+        "rx_packets": 0,
+        "rx_errors": 0,
+        "rx_dropped": 0,
+        "tx_bytes": 5,
+        "tx_packets": 0,
+        "tx_errors": 3,
+        "tx_dropped": 0
+      }
+    },
+    "network_rate_stats": {
+      "rx_bytes_per_sec": 0,
+      "tx_bytes_per_sec": 0
+    }
+  }
+}

--- a/src/biz/testdata/v4_task_metadata_response.json
+++ b/src/biz/testdata/v4_task_metadata_response.json
@@ -1,0 +1,94 @@
+{
+  "Cluster": "default",
+  "TaskARN": "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c",
+  "Family": "curltest",
+  "Revision": "26",
+  "DesiredStatus": "RUNNING",
+  "KnownStatus": "RUNNING",
+  "PullStartedAt": "2020-10-02T00:43:06.202617438Z",
+  "PullStoppedAt": "2020-10-02T00:43:06.31288465Z",
+  "AvailabilityZone": "us-west-2d",
+  "LaunchType": "EC2",
+  "Containers": [
+    {
+      "DockerId": "2bd0cbf916a2745ef9377277c33fd7e6582455d73feb0d22a15f421496d5f916",
+      "Name": "~internal~ecs~pause",
+      "DockerName": "ecs-curltest-26-internalecspause-e292d586b6f9dade4a00",
+      "Image": "amazon/amazon-ecs-pause:0.1.0",
+      "ImageID": "",
+      "Labels": {
+        "com.amazonaws.ecs.cluster": "default",
+        "com.amazonaws.ecs.container-name": "~internal~ecs~pause",
+        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:111122223333:task/default/f05a5672397746638bc201a252c5bb75",
+        "com.amazonaws.ecs.task-definition-family": "curltest",
+        "com.amazonaws.ecs.task-definition-version": "26"
+      },
+      "DesiredStatus": "RESOURCES_PROVISIONED",
+      "KnownStatus": "RESOURCES_PROVISIONED",
+      "Limits": {
+        "CPU": 0,
+        "Memory": 0
+      },
+      "CreatedAt": "2020-10-02T00:43:05.602352471Z",
+      "StartedAt": "2020-10-02T00:43:06.076707576Z",
+      "Type": "CNI_PAUSE",
+      "Networks": [
+        {
+          "NetworkMode": "awsvpc",
+          "IPv4Addresses": [
+            "10.0.2.61"
+          ],
+          "AttachmentIndex": 0,
+          "MACAddress": "0e:10:e2:01:bd:91",
+          "IPv4SubnetCIDRBlock": "10.0.2.0/24",
+          "PrivateDNSName": "ip-10-0-2-61.us-west-2.compute.internal",
+          "SubnetGatewayIpv4Address": "10.0.2.1/24"
+        }
+      ]
+    },
+    {
+      "DockerId": "ee08638adaaf009d78c248913f629e38299471d45fe7dc944d1039077e3424ca",
+      "Name": "curl",
+      "DockerName": "ecs-curltest-26-curl-a0e7dba5aca6d8cb2e00",
+      "Image": "111122223333.dkr.ecr.us-west-2.amazonaws.com/curltest:latest",
+      "ImageID": "sha256:d691691e9652791a60114e67b365688d20d19940dde7c4736ea30e660d8d3553",
+      "Labels": {
+        "com.amazonaws.ecs.cluster": "default",
+        "com.amazonaws.ecs.container-name": "curl",
+        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:111122223333:task/default/f05a5672397746638bc201a252c5bb75",
+        "com.amazonaws.ecs.task-definition-family": "curltest",
+        "com.amazonaws.ecs.task-definition-version": "26"
+      },
+      "DesiredStatus": "RUNNING",
+      "KnownStatus": "RUNNING",
+      "Limits": {
+        "CPU": 10,
+        "Memory": 128
+      },
+      "CreatedAt": "2020-10-02T00:43:06.326590752Z",
+      "StartedAt": "2020-10-02T00:43:06.767535449Z",
+      "Type": "NORMAL",
+      "LogDriver": "awslogs",
+      "LogOptions": {
+        "awslogs-create-group": "true",
+        "awslogs-group": "/ecs/metadata",
+        "awslogs-region": "us-west-2",
+        "awslogs-stream": "ecs/curl/158d1c8083dd49d6b527399fd6414f5c"
+      },
+      "ContainerARN": "arn:aws:ecs:us-west-2:111122223333:container/abb51bdd-11b4-467f-8f6c-adcfe1fe059d",
+      "Networks": [
+        {
+          "NetworkMode": "awsvpc",
+          "IPv4Addresses": [
+            "10.0.2.61"
+          ],
+          "AttachmentIndex": 0,
+          "MACAddress": "0e:10:e2:01:bd:91",
+          "IPv4SubnetCIDRBlock": "10.0.2.0/24",
+          "PrivateDNSName": "ip-10-0-2-61.us-west-2.compute.internal",
+          "SubnetGatewayIpv4Address": "10.0.2.1/24"
+        }
+      ]
+    }
+  ]
+}

--- a/src/docker.go
+++ b/src/docker.go
@@ -72,6 +72,7 @@ func main() {
 		var err error
 		var metadataBaseURL *url.URL
 		if metadataBaseURL, err = aws.MetadataV4BaseURL(); err != nil {
+			log.Debug("The Metadata endpoint V4 is not available, falling back to V3: %s", err.Error())
 			//If we do not find V4 we fall back to V3
 			metadataBaseURL, err = aws.MetadataV3BaseURL()
 		}

--- a/src/raw/aws/fargate_fetcher.go
+++ b/src/raw/aws/fargate_fetcher.go
@@ -20,7 +20,8 @@ const fargateTaskStatsCacheKey = "fargate-task-stats"
 var fargateHTTPClient = &http.Client{Timeout: fargateClientTimeout}
 
 type timedDockerStats struct {
-	docker.Stats
+	//StatsJSON inherits all the fields from docker.Stats adding Network info
+	docker.StatsJSON
 	time time.Time
 }
 
@@ -55,6 +56,9 @@ func (e *FargateFetcher) Fetch(container docker.ContainerJSON) (raw.Metrics, err
 		return raw.Metrics{}, err
 	}
 	rawMetrics := fargateRawMetrics(stats)
+	if rawMetrics[container.ID] == nil {
+		return raw.Metrics{}, fmt.Errorf("the raw metric map did nont contain the container with ID: %s, %d", container.ID, len(rawMetrics))
+	}
 	return *rawMetrics[container.ID], nil
 }
 

--- a/src/raw/aws/fargate_metadata.go
+++ b/src/raw/aws/fargate_metadata.go
@@ -25,9 +25,10 @@ import (
 )
 
 const (
-	containerMetadataEnvVar = "ECS_CONTAINER_METADATA_URI"
-	maxRetries              = 4
-	durationBetweenRetries  = time.Second
+	containerMetadataEnvVar   = "ECS_CONTAINER_METADATA_URI"
+	containerMetadataEnvVarV4 = "ECS_CONTAINER_METADATA_URI_V4"
+	maxRetries                = 4
+	durationBetweenRetries    = time.Second
 )
 
 // TaskResponse defines the schema for the task response JSON object
@@ -154,6 +155,20 @@ func MetadataV3BaseURL() (*url.URL, error) {
 	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse Metadata V3 API URL (%s): %s", baseURL, err)
+	}
+	return parsedURL, nil
+}
+
+// MetadataV4BaseURL returns the v4 metadata endpoint configured via the ECS_CONTAINER_METADATA_URI environment
+// variable.
+func MetadataV4BaseURL() (*url.URL, error) {
+	baseURL, found := os.LookupEnv(containerMetadataEnvVarV4)
+	if !found {
+		return nil, fmt.Errorf("could not find env var with Metadata V4 API URL: %s", containerMetadataEnvVarV4)
+	}
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse Metadata V4 API URL (%s): %s", baseURL, err)
 	}
 	return parsedURL, nil
 }

--- a/src/raw/network.go
+++ b/src/raw/network.go
@@ -82,6 +82,7 @@ func network(filePath string) (Network, error) {
 			continue
 		}
 
+		// we are computing the sum between all network interfaces
 		network.RxBytes += int64(rxBytes)
 		network.RxDropped += int64(rxDropped)
 		network.RxErrors += int64(rxErrors)


### PR DESCRIPTION
Adding support for[ Task metadata endpoint v4](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-v4-fargate.html)

```
The task metadata endpoint version 4 functions like the version 3 endpoint,
but provides additional network metadata for your containers and tasks. 
Additional network metrics are available when querying the /stats endpoints as well.
```