### PR TITLE
Do not add goversioninfo to the mod file

### DIFF
--- a/build/release.mk
+++ b/build/release.mk
@@ -21,7 +21,7 @@ release/clean:
 .PHONY : release/deps
 release/deps: $(GORELEASER_BIN)
 	@echo "===> $(INTEGRATION) === [release/deps] install goversioninfo"
-	@go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
+	@go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest
 
 .PHONY : release/build
 release/build: release/deps release/clean


### PR DESCRIPTION
- Install goversioninfo instead of go get to not add to go.mod