### PR TITLE
refactor: [BREAKING CHANGE] stop supporting cgroupspath and cgroupsdriver configuration

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -5,10 +5,8 @@ import "github.com/newrelic/infra-integrations-sdk/args"
 type ArgumentList struct {
 	args.DefaultArgumentList
 	HostRoot              string `default:"" help:"If the integration is running from a container, the mounted folder pointing to the host root folder"`
-	CgroupPath            string `default:"" help:"Optional. The path where cgroup is mounted."`
 	Fargate               bool   `default:"false" help:"Enables Fargate container metrics fetching. If enabled no metrics are collected from cgroups or Docker. Defaults to false"`
 	ExitedContainersTTL   string `default:"24h" help:"Enables to integration to stop reporting Exited containers that are older than the set TTL. Possible values are time-strings: 1s, 1m, 1h"`
-	CgroupDriver          string `default:"" help:"Optional. Specify the cgroup driver."`
 	DockerClientVersion   string `default:"1.24" help:"Optional. Specify the version of the docker client. Used for compatibility."`
 	DisableStorageMetrics bool   `default:"false" help:"Disables storage driver metrics collection."`
 	ShowVersion           bool   `default:"false" help:"Print build information and exit"`

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -10,4 +10,7 @@ type ArgumentList struct {
 	DockerClientVersion   string `default:"1.24" help:"Optional. Specify the version of the docker client. Used for compatibility."`
 	DisableStorageMetrics bool   `default:"false" help:"Disables storage driver metrics collection."`
 	ShowVersion           bool   `default:"false" help:"Print build information and exit"`
+	// CgroupPath and CgroupDriver arguments are not used but are kept here for backwards compatibility reasons.
+	CgroupPath   string `default:"" help:"Deprecated. cgroup_path argument is not used anymore."`
+	CgroupDriver string `default:"" help:"Deprecated. cgroup_driver argument is not used anymore."`
 }

--- a/src/docker.go
+++ b/src/docker.go
@@ -74,11 +74,7 @@ func main() {
 	} else {
 		detectedHostRoot, err := raw.DetectHostRoot(args.HostRoot, raw.CanAccessDir)
 		exitOnErr(err)
-		fetcher, err = raw.NewCgroupsFetcher(
-			detectedHostRoot,
-			args.CgroupDriver,
-			args.CgroupPath,
-		)
+		fetcher, err = raw.NewCgroupsFetcher(detectedHostRoot)
 		exitOnErr(err)
 		var tmpDocker *client.Client
 		tmpDocker, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion(args.DockerClientVersion))

--- a/src/raw/cgroup.go
+++ b/src/raw/cgroup.go
@@ -20,17 +20,13 @@ import (
 
 // CgroupsFetcher fetches the metrics that can be found in cgroups file system
 type CgroupsFetcher struct {
-	hostRoot         string
-	cgroupDriver     string
-	cgroupMountPoint string
+	hostRoot string
 }
 
 // NewCgroupsFetcher creates a new cgroups data fetcher.
-func NewCgroupsFetcher(hostRoot, cgroupDriver, cgroupMountPoint string) (*CgroupsFetcher, error) {
+func NewCgroupsFetcher(hostRoot string) (*CgroupsFetcher, error) {
 	return &CgroupsFetcher{
-		hostRoot:         hostRoot,
-		cgroupDriver:     cgroupDriver,
-		cgroupMountPoint: cgroupMountPoint,
+		hostRoot: hostRoot,
 	}, nil
 }
 
@@ -46,17 +42,7 @@ func (cg *CgroupsFetcher) Fetch(c types.ContainerJSON) (Metrics, error) {
 		cgroupInfo *cgroupPaths
 		err        error
 	)
-	if cg.cgroupMountPoint == "" {
-		cgroupInfo, err = getCgroupPaths(cg.hostRoot, pid)
-	} else {
-		var parent string
-		if c.HostConfig == nil || c.HostConfig.CgroupParent == "" {
-			parent = "docker"
-		} else {
-			parent = c.HostConfig.CgroupParent
-		}
-		cgroupInfo, err = getStaticCgroupPaths(cg.cgroupDriver, filepath.Join(cg.hostRoot, cg.cgroupMountPoint), parent, containerID)
-	}
+	cgroupInfo, err = getCgroupPaths(cg.hostRoot, pid)
 
 	if err != nil {
 		return stats, err

--- a/src/raw/cgroup_detect.go
+++ b/src/raw/cgroup_detect.go
@@ -17,34 +17,6 @@ const (
 	cgroupFilePathTpl = "/proc/%d/cgroup"
 )
 
-// TODO: This keeps the previous behavior if specified by configuration. Should be removed in future versions together with config arguments.
-func getStaticCgroupPaths(cgroupDriver, cgroupMountPoint, cgroupParent, containerID string) (*cgroupPaths, error) {
-
-	mountPoints := make(map[string]string)
-	paths := make(map[string]string)
-
-	for _, subsystem := range []string{
-		string(cgroups.Cpuset),
-		string(cgroups.Cpu),
-		string(cgroups.Cpuacct),
-		string(cgroups.Memory),
-		string(cgroups.Blkio),
-		string(cgroups.Pids),
-	} {
-		mountPoints[subsystem] = cgroupMountPoint
-		if cgroupDriver == "systemd" {
-			paths[subsystem] = fmt.Sprintf("/system.slice/%s-%s.scope", cgroupParent, containerID)
-		} else {
-			paths[subsystem] = fmt.Sprintf("/%s/%s", cgroupParent, containerID)
-		}
-	}
-
-	return &cgroupPaths{
-		mountPoints: mountPoints,
-		paths:       paths,
-	}, nil
-}
-
 // getCgroupPaths will detect the cgroup paths for a container pid.
 func getCgroupPaths(hostRoot string, pid int) (*cgroupPaths, error) {
 	return cgroupPathsFetch(hostRoot, pid, fileOpenFn)

--- a/src/raw/cgroup_detect_test.go
+++ b/src/raw/cgroup_detect_test.go
@@ -14,67 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetStaticCgroupPaths(t *testing.T) {
-
-	testCases := map[string]struct {
-		cgroupDriver string
-		expected     *cgroupPaths
-	}{
-		"CgroupDriver_SystemD": {
-			cgroupDriver: "cgroupfs",
-			expected: &cgroupPaths{
-				mountPoints: map[string]string{
-					"cpu":     "/sys/fs/cgroup",
-					"cpuset":  "/sys/fs/cgroup",
-					"cpuacct": "/sys/fs/cgroup",
-					"memory":  "/sys/fs/cgroup",
-					"blkio":   "/sys/fs/cgroup",
-					"pids":    "/sys/fs/cgroup",
-				},
-				paths: map[string]string{
-					"cpu":     "/docker/f7bd95ecd8dc9deb33491d044567db18f537fd9cf26613527ff5f636e7d9bdb0",
-					"cpuset":  "/docker/f7bd95ecd8dc9deb33491d044567db18f537fd9cf26613527ff5f636e7d9bdb0",
-					"cpuacct": "/docker/f7bd95ecd8dc9deb33491d044567db18f537fd9cf26613527ff5f636e7d9bdb0",
-					"memory":  "/docker/f7bd95ecd8dc9deb33491d044567db18f537fd9cf26613527ff5f636e7d9bdb0",
-					"blkio":   "/docker/f7bd95ecd8dc9deb33491d044567db18f537fd9cf26613527ff5f636e7d9bdb0",
-					"pids":    "/docker/f7bd95ecd8dc9deb33491d044567db18f537fd9cf26613527ff5f636e7d9bdb0",
-				},
-			},
-		},
-		"CgroupDriver_Cgroupfs": {
-			cgroupDriver: "systemd",
-			expected: &cgroupPaths{
-				mountPoints: map[string]string{
-					"cpu":     "/sys/fs/cgroup",
-					"cpuset":  "/sys/fs/cgroup",
-					"cpuacct": "/sys/fs/cgroup",
-					"memory":  "/sys/fs/cgroup",
-					"blkio":   "/sys/fs/cgroup",
-					"pids":    "/sys/fs/cgroup",
-				},
-				paths: map[string]string{
-					"cpu":     "/system.slice/docker-f7bd95ecd8dc9deb33491d044567db18f537fd9cf26613527ff5f636e7d9bdb0.scope",
-					"cpuset":  "/system.slice/docker-f7bd95ecd8dc9deb33491d044567db18f537fd9cf26613527ff5f636e7d9bdb0.scope",
-					"cpuacct": "/system.slice/docker-f7bd95ecd8dc9deb33491d044567db18f537fd9cf26613527ff5f636e7d9bdb0.scope",
-					"memory":  "/system.slice/docker-f7bd95ecd8dc9deb33491d044567db18f537fd9cf26613527ff5f636e7d9bdb0.scope",
-					"blkio":   "/system.slice/docker-f7bd95ecd8dc9deb33491d044567db18f537fd9cf26613527ff5f636e7d9bdb0.scope",
-					"pids":    "/system.slice/docker-f7bd95ecd8dc9deb33491d044567db18f537fd9cf26613527ff5f636e7d9bdb0.scope",
-				},
-			},
-		},
-	}
-
-	for testName, testCase := range testCases {
-		t.Run(testName, func(t *testing.T) {
-			actual, err := getStaticCgroupPaths(testCase.cgroupDriver, "/sys/fs/cgroup", "docker", "f7bd95ecd8dc9deb33491d044567db18f537fd9cf26613527ff5f636e7d9bdb0")
-
-			assert.NoError(t, err)
-			assert.Equal(t, testCase.expected, actual)
-		})
-	}
-
-}
-
 func TestParseCgroupMountPoints(t *testing.T) {
 
 	testCases := map[string]struct {

--- a/tests/integration/cgroups_fetcher_mock_test.go
+++ b/tests/integration/cgroups_fetcher_mock_test.go
@@ -1,9 +1,10 @@
 package biz
 
 import (
+	"time"
+
 	"github.com/docker/docker/api/types"
 	"github.com/newrelic/nri-docker/src/raw"
-	"time"
 )
 
 // CgroupsFetcherMock is a wrapper of CgroupsFetcher to mock:
@@ -16,8 +17,8 @@ type CgroupsFetcherMock struct {
 }
 
 // NewCgroupsFetcherMock creates a new cgroups data fetcher.
-func NewCgroupsFetcherMock(hostRoot, cgroupDriver, cgroupMountPoint string, time time.Time, systemUsage uint64) (*CgroupsFetcherMock, error) {
-	cgroupsFetcher, err := raw.NewCgroupsFetcher(hostRoot, cgroupDriver, cgroupMountPoint)
+func NewCgroupsFetcherMock(hostRoot string, time time.Time, systemUsage uint64) (*CgroupsFetcherMock, error) {
+	cgroupsFetcher, err := raw.NewCgroupsFetcher(hostRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/integration/metrics_test.go
+++ b/tests/integration/metrics_test.go
@@ -43,7 +43,7 @@ func TestHighCPU(t *testing.T) {
 	docker := newDocker(t)
 	defer docker.Close()
 
-	cgroupFetcher, err := raw.NewCgroupsFetcher("/", "cgroupfs", "")
+	cgroupFetcher, err := raw.NewCgroupsFetcher("/")
 	require.NoError(t, err)
 
 	metrics := biz.NewProcessor(
@@ -90,7 +90,7 @@ func TestLowCPU(t *testing.T) {
 	docker := newDocker(t)
 	defer docker.Close()
 
-	cgroupFetcher, err := raw.NewCgroupsFetcher("/", "cgroupfs", "")
+	cgroupFetcher, err := raw.NewCgroupsFetcher("/")
 	require.NoError(t, err)
 
 	metrics := biz.NewProcessor(
@@ -128,7 +128,7 @@ func TestMemory(t *testing.T) {
 	docker := newDocker(t)
 	defer docker.Close()
 
-	cgroupFetcher, err := raw.NewCgroupsFetcher("/", "cgroupfs", "")
+	cgroupFetcher, err := raw.NewCgroupsFetcher("/")
 	require.NoError(t, err)
 
 	metrics := biz.NewProcessor(
@@ -203,7 +203,7 @@ func TestExitedContainersWithTTL(t *testing.T) {
 	docker := newDocker(t)
 	defer docker.Close()
 
-	cgroupFetcher, err := raw.NewCgroupsFetcher("/", "cgroupfs", "")
+	cgroupFetcher, err := raw.NewCgroupsFetcher("/")
 	require.NoError(t, err)
 
 	metrics := biz.NewProcessor(persist.NewInMemoryStore(), cgroupFetcher, docker, 1*time.Second)
@@ -222,7 +222,7 @@ func TestExitedContainersWithoutTTL(t *testing.T) {
 	docker := newDocker(t)
 	defer docker.Close()
 
-	cgroupFetcher, err := raw.NewCgroupsFetcher("/", "cgroupfs", "")
+	cgroupFetcher, err := raw.NewCgroupsFetcher("/")
 	require.NoError(t, err)
 
 	metrics := biz.NewProcessor(persist.NewInMemoryStore(), cgroupFetcher, docker, 0)
@@ -300,7 +300,7 @@ func TestAllMetricsPresent(t *testing.T) {
 
 	// CgroupsFetcherMock is the raw CgroupsFetcher with mocked cpu.systemUsage and time
 	// The hostRoot is our mocked filesystem
-	cgroupFetcher, err := NewCgroupsFetcherMock(hostRoot, "cgroupfs", "", mockedTimeForAllMetricsTest, 19026130000000)
+	cgroupFetcher, err := NewCgroupsFetcherMock(hostRoot, mockedTimeForAllMetricsTest, 19026130000000)
 	require.NoError(t, err)
 
 	storer := inMemoryStorerWithPreviousCPUState()


### PR DESCRIPTION
## Possible BREAKING CHANGE

Although the removed has been _marked as deprecated_ long ago and the removed configuration arguments don't appear either in documentation or in examples, those are two configuration parameters being removed. Therefore, any user relying on them could be affected.