### PR TITLE
Refactor cgroups detectors

### DIFF
--- a/src/docker.go
+++ b/src/docker.go
@@ -84,7 +84,12 @@ func main() {
 		cgroupInfo, err := raw.GetCgroupInfo(context.Background(), docker)
 		exitOnErr(err)
 
-		fetcher, err = raw.NewCgroupsFetcher(detectedHostRoot, cgroupInfo, raw.NewPosixSystemCPUReader())
+		fetcher, err = raw.NewCgroupsFetcher(
+			detectedHostRoot,
+			cgroupInfo,
+			raw.NewPosixSystemCPUReader(),
+			raw.NetDevNetworkStatsGetter{},
+		)
 		exitOnErr(err)
 	}
 	sampler, err := nri.NewSampler(fetcher, docker, exitedContainerTTL, args)

--- a/src/raw/cgroup.go
+++ b/src/raw/cgroup.go
@@ -9,12 +9,17 @@ import (
 )
 
 // NewCgroupsFetcher creates the proper metrics fetcher for the used cgroups version.
-func NewCgroupsFetcher(hostRoot string, cgroupInfo *CgroupInfo, systemCPUReader SystemCPUReader) (Fetcher, error) {
+func NewCgroupsFetcher(
+	hostRoot string,
+	cgroupInfo *CgroupInfo,
+	systemCPUReader SystemCPUReader,
+	networkStatsGetter NetworkStatsGetter,
+) (Fetcher, error) {
 	if cgroupInfo.Version == CgroupV2 {
-		return NewCgroupsV2Fetcher(hostRoot, systemCPUReader, cgroupInfo.Driver)
+		return NewCgroupsV2Fetcher(hostRoot, cgroupInfo.Driver, NewCgroupsV2Detector(), systemCPUReader, networkStatsGetter)
 	}
 
-	return NewCgroupsV1Fetcher(hostRoot, systemCPUReader)
+	return NewCgroupsV1Fetcher(hostRoot, NewCgroupsV1Detector(), systemCPUReader, networkStatsGetter)
 }
 
 func countCpusetCPUsFromPath(path string) (uint, error) {

--- a/src/raw/cgroup_detect.go
+++ b/src/raw/cgroup_detect.go
@@ -1,17 +1,119 @@
 package raw
 
 import (
+	"bufio"
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/newrelic/infra-integrations-sdk/log"
 )
 
 const (
-	mountsFilePath    = "/proc/mounts"
-	cgroupFilePathTpl = "/proc/%d/cgroup"
+	mountsFilePath           = "/proc/mounts"
+	cgroupFilePathTpl        = "/proc/%d/cgroup"
+	cgroup1MountName         = "cgroup"
+	cgroup2MountName         = "cgroup2"
+	cgroup2UnifiedFilesystem = "/"
 )
+
+type CgroupDetector interface {
+	PopulatePaths(hostRoot string, pid int) error
+}
 
 type fileOpenFn func(string) (io.ReadCloser, error)
 
 func defaultFileOpenFn(filePath string) (io.ReadCloser, error) {
 	return os.Open(filePath)
+}
+
+func getMountsFile(hostRoot string, mountPoints map[string]string, cgroupMountPointName string, fileOpen fileOpenFn) error {
+	path := filepath.Join(hostRoot, mountsFilePath)
+	mountsFile, err := fileOpen(path)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %s, while detecting cgroup mountpoints error: %v",
+			mountsFilePath, err)
+	}
+
+	defer func() {
+		if closeErr := mountsFile.Close(); closeErr != nil {
+			log.Error("Error occurred while closing the file: %v", closeErr)
+		}
+	}()
+
+	sc := bufio.NewScanner(mountsFile)
+	for sc.Scan() {
+		line := sc.Text()
+		fields := strings.Fields(line)
+
+		switch cgroupMountPointName {
+		case cgroup1MountName:
+			// Filter mount points if the type is not 'cgroup' or not mounted under </host>/sys
+			if len(fields) < 3 || !strings.HasPrefix(fields[2], cgroup1MountName) || !strings.HasPrefix(fields[1], hostRoot) {
+				continue
+			}
+
+			for _, subsystem := range strings.Split(filepath.Base(fields[1]), ",") {
+				if _, found := mountPoints[subsystem]; !found {
+					mountPoints[subsystem] = filepath.Dir(fields[1])
+				}
+			}
+		case cgroup2MountName:
+			if len(fields) >= 3 && strings.HasPrefix(fields[2], cgroup2MountName) && strings.HasPrefix(fields[1], hostRoot) {
+				mountPoints[cgroup2UnifiedFilesystem] = fields[1]
+				return nil
+			}
+		default:
+		}
+	}
+
+	return sc.Err()
+}
+
+func getCgroupFilePaths(
+	hostRoot string,
+	pid int,
+	cgroupPaths map[string]string,
+	cgroupMountPointName string,
+	fileOpen fileOpenFn,
+) error {
+	cgroupFilePath := filepath.Join(hostRoot, fmt.Sprintf(cgroupFilePathTpl, pid))
+	cgroupFile, err := fileOpen(cgroupFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %s, while detecting cgroup paths error: %v",
+			cgroupFilePath, err)
+	}
+
+	defer func() {
+		if closeErr := cgroupFile.Close(); closeErr != nil {
+			log.Error("Error occurred while closing the file: %v", closeErr)
+		}
+	}()
+
+	sc := bufio.NewScanner(cgroupFile)
+	for sc.Scan() {
+		line := sc.Text()
+		fields := strings.Split(line, ":")
+
+		if len(fields) != 3 {
+			return fmt.Errorf("unexpected cgroup file format: \"%s\"", line)
+		}
+
+		switch cgroupMountPointName {
+		case cgroup1MountName:
+			for _, subsystem := range strings.Split(fields[1], ",") {
+				cgroupPaths[subsystem] = fields[2]
+			}
+		case cgroup2MountName:
+			if fields[0] == "0" && fields[1] == "" {
+				cgroupPaths[cgroup2UnifiedFilesystem] = fields[2]
+				return nil
+			}
+		default:
+		}
+	}
+
+	return sc.Err()
 }

--- a/src/raw/cgroupv1_detect.go
+++ b/src/raw/cgroupv1_detect.go
@@ -1,60 +1,40 @@
 package raw
 
 import (
-	"bufio"
 	"fmt"
-	"io"
 	"path/filepath"
-	"strings"
 
 	"github.com/containerd/cgroups"
-	"github.com/newrelic/infra-integrations-sdk/log"
 )
 
-// getCgroupV1Paths will detect the cgroup paths for a container pid.
-func getCgroupV1Paths(hostRoot string, pid int) (*cgroupV1Paths, error) {
-	return cgroupV1PathsFetch(hostRoot, pid, defaultFileOpenFn)
+type CgoupsV1Detector struct {
+	openFn fileOpenFn
+	paths  *cgroupV1Paths
 }
 
-func cgroupV1PathsFetch(hostRoot string, pid int, fileOpen fileOpenFn) (*cgroupV1Paths, error) {
+func NewCgroupsV1Detector() *CgoupsV1Detector {
+	return &CgoupsV1Detector{openFn: defaultFileOpenFn}
+}
 
-	mountsFilePath := filepath.Join(hostRoot, mountsFilePath)
-	mountsFile, err := fileOpen(mountsFilePath)
+func (cgd *CgoupsV1Detector) PopulatePaths(hostRoot string, pid int) error {
+	mountPoints := make(map[string]string)
+	err := getMountsFile(hostRoot, mountPoints, cgroup1MountName, cgd.openFn)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open file: %s, while detecting cgroup mountpoints error: %v",
-			mountsFilePath, err)
-	}
-	defer func() {
-		if closeErr := mountsFile.Close(); closeErr != nil {
-			log.Error("Error occurred while closing the file: %v", closeErr)
-		}
-	}()
-
-	mountPoints, err := parseCgroupV1MountPoints(hostRoot, mountsFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse cgroup mountpoints error: %v", err)
+		return fmt.Errorf("failed to parse cgroups mountpoints: %v", err)
 	}
 
-	cgroupFilePath := filepath.Join(hostRoot, fmt.Sprintf(cgroupFilePathTpl, pid))
-	cgroupFile, err := fileOpen(cgroupFilePath)
+	cgroupPaths := make(map[string]string)
+	err = getCgroupFilePaths(hostRoot, pid, cgroupPaths, cgroup1MountName, cgd.openFn)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open file: %s, while detecting cgroup paths error: %v",
-			cgroupFilePath, err)
-	}
-	defer func() {
-		if closeErr := cgroupFile.Close(); closeErr != nil {
-			log.Error("Error occurred while closing the file: %v", closeErr)
-		}
-	}()
-	paths, err := parseCgroupV1Paths(cgroupFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse cgroup paths error: %v", err)
+		return fmt.Errorf("failed to parse cgroup paths error: %v", err)
 	}
 
-	return &cgroupV1Paths{
+	cgd.paths = &cgroupV1Paths{
 		mountPoints: mountPoints,
-		paths:       paths,
-	}, nil
+		paths:       cgroupPaths,
+	}
+
+	return nil
 }
 
 type cgroupV1Paths struct {
@@ -62,17 +42,7 @@ type cgroupV1Paths struct {
 	paths       map[string]string
 }
 
-func (cgi *cgroupV1Paths) getPath(name cgroups.Name) (string, error) {
-
-	if result, ok := cgi.paths[string(name)]; ok {
-		return result, nil
-	}
-
-	return "", fmt.Errorf("cgroup path not found for subsystem %s", name)
-}
-
 func (cgi *cgroupV1Paths) getMountPoint(name cgroups.Name) (string, error) {
-
 	if result, ok := cgi.mountPoints[string(name)]; ok {
 		return result, nil
 	}
@@ -80,8 +50,27 @@ func (cgi *cgroupV1Paths) getMountPoint(name cgroups.Name) (string, error) {
 	return "", fmt.Errorf("cgroup mount point not found for subsystem %s", name)
 }
 
-func (cgi *cgroupV1Paths) getFullPath(name cgroups.Name) (string, error) {
+func (cgi *cgroupV1Paths) getPath(name cgroups.Name) (string, error) {
+	if result, ok := cgi.paths[string(name)]; ok {
+		return result, nil
+	}
 
+	return "", fmt.Errorf("cgroup path not found for subsystem %s", name)
+}
+
+func (cgi *cgroupV1Paths) getSingleFileUintStat(name cgroups.Name, stat string) (uint64, error) {
+	fp, err := cgi.getFullPath(name)
+	if err != nil {
+		return 0, err
+	}
+	c, err := ParseStatFileContentUint64(filepath.Join(fp, stat))
+	if err != nil {
+		return 0, err
+	}
+	return c, nil
+}
+
+func (cgi *cgroupV1Paths) getFullPath(name cgroups.Name) (string, error) {
 	cgroupMountPoint, err := cgi.getMountPoint(name)
 	if err != nil {
 		return "", err
@@ -122,66 +111,4 @@ func (cgi *cgroupV1Paths) getHierarchyFn() cgroups.Hierarchy {
 
 		return subsystems, nil
 	}
-}
-
-func (cgi *cgroupV1Paths) getSingleFileUintStat(name cgroups.Name, stat string) (uint64, error) {
-	fp, err := cgi.getFullPath(name)
-	if err != nil {
-		return 0, err
-	}
-	c, err := ParseStatFileContentUint64(filepath.Join(fp, stat))
-	if err != nil {
-		return 0, err
-	}
-	return c, nil
-}
-
-func parseCgroupV1MountPoints(hostRoot string, mountFileInfo io.Reader) (map[string]string, error) {
-	mountPoints := make(map[string]string)
-
-	sc := bufio.NewScanner(mountFileInfo)
-	for sc.Scan() {
-		line := sc.Text()
-		fields := strings.Fields(line)
-
-		// Filter mount points if the type is not 'cgroup' or not mounted under </host>/sys
-		if len(fields) < 3 || !strings.HasPrefix(fields[2], "cgroup") || !strings.HasPrefix(fields[1], hostRoot) {
-			continue
-		}
-
-		for _, subsystem := range strings.Split(filepath.Base(fields[1]), ",") {
-			if _, found := mountPoints[subsystem]; !found {
-				mountPoints[subsystem] = filepath.Dir(fields[1])
-			}
-		}
-	}
-	if err := sc.Err(); err != nil {
-		return nil, err
-	}
-
-	return mountPoints, nil
-}
-
-func parseCgroupV1Paths(cgroupFile io.Reader) (map[string]string, error) {
-	cgroupPaths := make(map[string]string)
-
-	sc := bufio.NewScanner(cgroupFile)
-	for sc.Scan() {
-		line := sc.Text()
-		fields := strings.Split(line, ":")
-
-		if len(fields) != 3 {
-			return nil, fmt.Errorf("unexpected cgroup file format: \"%s\"", line)
-		}
-
-		for _, subsystem := range strings.Split(fields[1], ",") {
-			cgroupPaths[subsystem] = fields[2]
-		}
-	}
-
-	if err := sc.Err(); err != nil {
-		return nil, err
-	}
-
-	return cgroupPaths, nil
 }

--- a/src/raw/cgroupv2.go
+++ b/src/raw/cgroupv2.go
@@ -15,19 +15,29 @@ import (
 
 // CgroupsV2Fetcher fetches the metrics that can be found in cgroups (v2) file system
 type CgroupsV2Fetcher struct {
-	cgroupDriver    string
-	hostRoot        string
-	systemCPUReader SystemCPUReader
-	cpuCounter      func(effectiveCPUsPath string) (uint, error)
+	cgroupDriver       string
+	hostRoot           string
+	cgroupDetector     CgroupDetector
+	systemCPUReader    SystemCPUReader
+	networkStatsGetter NetworkStatsGetter
+	cpuCounter         func(effectiveCPUsPath string) (uint, error)
 }
 
 // NewCgroupsV2Fetcher creates a new cgroups data fetcher.
-func NewCgroupsV2Fetcher(hostRoot string, systemCPUReader SystemCPUReader, cgroupDriver string) (*CgroupsV2Fetcher, error) {
+func NewCgroupsV2Fetcher(
+	hostRoot string,
+	cgroupDriver string,
+	cgroupDetector CgroupDetector,
+	systemCPUReader SystemCPUReader,
+	networkStatsGetter NetworkStatsGetter,
+) (*CgroupsV2Fetcher, error) {
 	return &CgroupsV2Fetcher{
-		cgroupDriver:    cgroupDriver,
-		hostRoot:        hostRoot,
-		systemCPUReader: systemCPUReader,
-		cpuCounter:      countCpusetCPUsFromPath,
+		cgroupDriver:       cgroupDriver,
+		hostRoot:           hostRoot,
+		cgroupDetector:     cgroupDetector,
+		systemCPUReader:    systemCPUReader,
+		networkStatsGetter: networkStatsGetter,
+		cpuCounter:         countCpusetCPUsFromPath,
 	}, nil
 }
 
@@ -40,17 +50,14 @@ func (cg *CgroupsV2Fetcher) Fetch(c types.ContainerJSON) (Metrics, error) {
 	pid := c.State.Pid
 	containerID := c.ID
 
-	var (
-		cgroupInfo *cgroupV2Paths
-		err        error
-	)
-
-	cgroupInfo, err = getCgroupV2Paths(cg.hostRoot, pid, cg.cgroupDriver, containerID)
+	err := cg.cgroupDetector.PopulatePaths(cg.hostRoot, pid)
 	if err != nil {
 		return stats, err
 	}
 
-	manager, err := cgroupsV2.LoadManager(cgroupInfo.MountPoint, cgroupInfo.Group)
+	cgroupInfo := cg.cgroupDetector.(*CgoupsV2Detector).paths
+
+	manager, err := cgroupsV2.LoadManager(cgroupInfo.mountPoint, cgroupInfo.group)
 	if err != nil {
 		return stats, err
 	}
@@ -70,11 +77,11 @@ func (cg *CgroupsV2Fetcher) Fetch(c types.ContainerJSON) (Metrics, error) {
 		log.Error("couldn't read cpu stats: %v", err)
 	}
 
-	if stats.CPU.Shares, err = getSingleFileUintStat(cgroupInfo, "cpu.weight"); err != nil {
+	if stats.CPU.Shares, err = cgroupInfo.getSingleFileUintStat("cpu.weight"); err != nil {
 		log.Error("couldn't read cpu weight: %v", err)
 	}
 
-	cpusetPath := filepath.Join(cgroupInfo.FullPath(), "cpuset.cpus.effective")
+	cpusetPath := filepath.Join(cgroupInfo.getFullPath(), "cpuset.cpus.effective")
 	if stats.CPU.OnlineCPUs, err = cg.cpuCounter(cpusetPath); err != nil {
 		log.Error("couldn't get cpu count: %v", err)
 	}
@@ -88,19 +95,9 @@ func (cg *CgroupsV2Fetcher) Fetch(c types.ContainerJSON) (Metrics, error) {
 	}
 
 	stats.ContainerID = containerID
+	stats.Network, err = cg.networkStatsGetter.GetForContainer(cg.hostRoot, strconv.Itoa(pid), containerID)
 
-	netMetricsPath := filepath.Join(cg.hostRoot, "/proc", strconv.Itoa(pid), "net", "dev")
-	stats.Network, err = network(netMetricsPath)
-	if err != nil {
-		log.Error(
-			"couldn't fetch network stats for container %s from cgroups: %v",
-			containerID,
-			err,
-		)
-		return stats, err
-	}
-
-	return stats, nil
+	return stats, err
 }
 
 func (cg *CgroupsV2Fetcher) cpu(metric *cgroupstatsV2.Metrics) (CPU, error) {

--- a/src/raw/cgroupv2_detect_test.go
+++ b/src/raw/cgroupv2_detect_test.go
@@ -24,9 +24,11 @@ func TestSplitMountPointAndGroup(t *testing.T) {
 		},
 	}
 
+	cgroupDetector := NewCgroupsV2Detector()
+
 	for _, c := range cases {
 		t.Run("check "+c.fullPath, func(t *testing.T) {
-			mountpoint, group := splitMountPointAndGroup(c.fullPath)
+			mountpoint, group := cgroupDetector.splitMountPointAndGroup(c.fullPath)
 			assert.Equal(t, c.mountPoint, mountpoint)
 			assert.Equal(t, c.group, group)
 		})
@@ -93,10 +95,12 @@ tmpfs /run/user/1000 tmpfs rw,nosuid,nodev,relatime,size=99456k,nr_inodes=24864,
 		},
 	}
 
+	cgroupDetector := NewCgroupsV2Detector()
+
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
-			fn := createFileOpenFnMock(c.FilesContent)
-			mountPoint, err := cgroupV2FullPath(c.HostRoot, c.Pid, fn)
+			cgroupDetector.openFn = createFileOpenFnMock(c.FilesContent)
+			mountPoint, err := cgroupDetector.cgroupV2FullPath(c.HostRoot, c.Pid)
 			require.NoError(t, err)
 			assert.Equal(t, c.Expected, mountPoint)
 		})
@@ -180,10 +184,12 @@ tmpfs /run/user/1000 tmpfs rw,nosuid,nodev,relatime,size=99456k,nr_inodes=24864,
 		},
 	}
 
+	cgroupDetector := NewCgroupsV2Detector()
+
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
-			fn := createFileOpenFnMock(c.FilesContent)
-			_, err := cgroupV2FullPath(c.HostRoot, c.Pid, fn)
+			cgroupDetector.openFn = createFileOpenFnMock(c.FilesContent)
+			_, err := cgroupDetector.cgroupV2FullPath(c.HostRoot, c.Pid)
 			require.Error(t, err)
 		})
 	}

--- a/test/integration/cgroups_fetcher_mock_test.go
+++ b/test/integration/cgroups_fetcher_mock_test.go
@@ -18,7 +18,7 @@ type CgroupsFetcherMock struct {
 
 // NewCgroupsFetcherMock creates a new cgroups data fetcher.
 func NewCgroupsFetcherMock(hostRoot string, time time.Time, systemUsage uint64) (*CgroupsFetcherMock, error) {
-	cgroupsFetcher, err := raw.NewCgroupsV1Fetcher(hostRoot, NewSystemCPUReaderMock(systemUsage))
+	cgroupsFetcher, err := raw.NewCgroupsV1Fetcher(hostRoot, raw.NewCgroupsV1Detector(), NewSystemCPUReaderMock(systemUsage), raw.NetDevNetworkStatsGetter{})
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/metrics_test.go
+++ b/test/integration/metrics_test.go
@@ -43,7 +43,12 @@ func TestHighCPU(t *testing.T) {
 	docker := newDocker(t)
 	defer docker.Close()
 
-	cgroupFetcher, err := raw.NewCgroupsV1Fetcher("/", raw.NewPosixSystemCPUReader())
+	cgroupFetcher, err := raw.NewCgroupsV1Fetcher(
+		"/",
+		raw.NewCgroupsV1Detector(),
+		raw.NewPosixSystemCPUReader(),
+		raw.NetDevNetworkStatsGetter{},
+	)
 	require.NoError(t, err)
 
 	metrics := biz.NewProcessor(
@@ -90,7 +95,12 @@ func TestLowCPU(t *testing.T) {
 	docker := newDocker(t)
 	defer docker.Close()
 
-	cgroupFetcher, err := raw.NewCgroupsV1Fetcher("/", raw.NewPosixSystemCPUReader())
+	cgroupFetcher, err := raw.NewCgroupsV1Fetcher(
+		"/",
+		raw.NewCgroupsV1Detector(),
+		raw.NewPosixSystemCPUReader(),
+		raw.NetDevNetworkStatsGetter{},
+	)
 	require.NoError(t, err)
 
 	metrics := biz.NewProcessor(
@@ -128,7 +138,12 @@ func TestMemory(t *testing.T) {
 	docker := newDocker(t)
 	defer docker.Close()
 
-	cgroupFetcher, err := raw.NewCgroupsV1Fetcher("/", raw.NewPosixSystemCPUReader())
+	cgroupFetcher, err := raw.NewCgroupsV1Fetcher(
+		"/",
+		raw.NewCgroupsV1Detector(),
+		raw.NewPosixSystemCPUReader(),
+		raw.NetDevNetworkStatsGetter{},
+	)
 	require.NoError(t, err)
 
 	metrics := biz.NewProcessor(
@@ -203,7 +218,12 @@ func TestExitedContainersWithTTL(t *testing.T) {
 	docker := newDocker(t)
 	defer docker.Close()
 
-	cgroupFetcher, err := raw.NewCgroupsV1Fetcher("/", raw.NewPosixSystemCPUReader())
+	cgroupFetcher, err := raw.NewCgroupsV1Fetcher(
+		"/",
+		raw.NewCgroupsV1Detector(),
+		raw.NewPosixSystemCPUReader(),
+		raw.NetDevNetworkStatsGetter{},
+	)
 	require.NoError(t, err)
 
 	metrics := biz.NewProcessor(persist.NewInMemoryStore(), cgroupFetcher, docker, 1*time.Second)
@@ -222,7 +242,12 @@ func TestExitedContainersWithoutTTL(t *testing.T) {
 	docker := newDocker(t)
 	defer docker.Close()
 
-	cgroupFetcher, err := raw.NewCgroupsV1Fetcher("/", raw.NewPosixSystemCPUReader())
+	cgroupFetcher, err := raw.NewCgroupsV1Fetcher(
+		"/",
+		raw.NewCgroupsV1Detector(),
+		raw.NewPosixSystemCPUReader(),
+		raw.NetDevNetworkStatsGetter{},
+	)
 	require.NoError(t, err)
 
 	metrics := biz.NewProcessor(persist.NewInMemoryStore(), cgroupFetcher, docker, 0)


### PR DESCRIPTION
- Refactor cgroups detector to have same logic for both cgroups and be able to mock detector.