### PR TITLE
Add ci job to run integration tests on ubuntu 22.04

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ env:
   GO_VERSION: '1.18'
 
 jobs:
-  e2eTests:
+  e2eTests-cgroups-v1:
     # Do not run e2e tests if commit message or PR has skip-e2e.
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
     runs-on: ubuntu-20.04
@@ -22,6 +22,27 @@ jobs:
         run: |
           GOOS=linux GOARCH=amd64 make compile
       - name: Run E2E for Cgroups v1
+        uses: newrelic/newrelic-integration-e2e-action@v1
+        with:
+          spec_path: test/e2e/e2e_spec.yml
+          account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
+          api_key: ${{ secrets.COREINT_E2E_API_KEY }}
+          license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
+  e2eTests-cgroups-v2:
+    # Do not run e2e tests if commit message or PR has skip-e2e.
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout-repository
+        uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Compile nri-docker
+        run: |
+          GOOS=linux GOARCH=amd64 make compile
+      - name: Run E2E for Cgroups v2
         uses: newrelic/newrelic-integration-e2e-action@v1
         with:
           spec_path: test/e2e/e2e_spec.yml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ env:
   GO_VERSION: '1.18'
 
 jobs:
-  e2eTests-cgroups-v1:
+  e2eTests:
     # Do not run e2e tests if commit message or PR has skip-e2e.
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
     runs-on: ubuntu-20.04
@@ -22,27 +22,6 @@ jobs:
         run: |
           GOOS=linux GOARCH=amd64 make compile
       - name: Run E2E for Cgroups v1
-        uses: newrelic/newrelic-integration-e2e-action@v1
-        with:
-          spec_path: test/e2e/e2e_spec.yml
-          account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
-          api_key: ${{ secrets.COREINT_E2E_API_KEY }}
-          license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
-  e2eTests-cgroups-v2:
-    # Do not run e2e tests if commit message or PR has skip-e2e.
-    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: checkout-repository
-        uses: actions/checkout@v2
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      - name: Compile nri-docker
-        run: |
-          GOOS=linux GOARCH=amd64 make compile
-      - name: Run E2E for Cgroups v2
         uses: newrelic/newrelic-integration-e2e-action@v1
         with:
           spec_path: test/e2e/e2e_spec.yml

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -71,6 +71,34 @@ jobs:
           GOPATH: ${{ github.workspace }}
         run: make integration-test
 
+  test-cgroups-v2-integration-nix:
+    name: Run integration tests for cgroups v2 on *Nix
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          path: src/github.com/${{env.ORIGINAL_REPO_NAME}}
+      - name: Login to DockerHub
+        if: ${{env.DOCKER_LOGIN_AVAILABLE}}
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+          password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Integration test
+        env:
+          GOPATH: ${{ github.workspace }}
+        continue-on-error: true
+        run: make integration-test
+
   test-build:
     name: Test binary compilation for all platforms:arch
     runs-on: ubuntu-20.04

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -96,7 +96,6 @@ jobs:
       - name: Integration test
         env:
           GOPATH: ${{ github.workspace }}
-        continue-on-error: true
         run: make integration-test
 
   test-build:


### PR DESCRIPTION
Closes https://github.com/newrelic/nri-docker/issues/122.

Add CI job to run integration tests on ubuntu 22.04, supporting cgroups v2. However, there are apparently some issues as reflected in this issue comments https://github.com/actions/virtual-environments/issues/5490#issuecomment-1118319996 so we allow the job to fail.