### PR TITLE
Add ci job to run e2e tests for cgroups v2

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
   e2eTests-cgroups-v2:
     # Do not run e2e tests if commit message or PR has skip-e2e.
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout-repository
         uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ env:
   GO_VERSION: '1.18'
 
 jobs:
-  e2eTests:
+  e2eTests-cgroups-v1:
     # Do not run e2e tests if commit message or PR has skip-e2e.
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
     runs-on: ubuntu-20.04
@@ -22,6 +22,27 @@ jobs:
         run: |
           GOOS=linux GOARCH=amd64 make compile
       - name: Run E2E for Cgroups v1
+        uses: newrelic/newrelic-integration-e2e-action@v1
+        with:
+          spec_path: test/e2e/e2e_spec.yml
+          account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
+          api_key: ${{ secrets.COREINT_E2E_API_KEY }}
+          license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
+  e2eTests-cgroups-v2:
+    # Do not run e2e tests if commit message or PR has skip-e2e.
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout-repository
+        uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Compile nri-docker
+        run: |
+          GOOS=linux GOARCH=amd64 make compile
+      - name: Run E2E for Cgroups v2
         uses: newrelic/newrelic-integration-e2e-action@v1
         with:
           spec_path: test/e2e/e2e_spec.yml

--- a/test/e2e/e2e_spec.yml
+++ b/test/e2e/e2e_spec.yml
@@ -25,7 +25,11 @@ scenarios:
       metrics:
         - source: "docker.yml"
           except_metrics:
+            - docker.container.memorySizeLimitBytes
             - docker.container.memorySoftLimitBytes
+            - docker.container.memorySwapLimitBytes
+            - docker.container.memorySwapLimitUsagePercent
+            - docker.container.memoryUsageLimitPercent
             - docker.container.pids
             - docker.container.processCount
             - docker.container.processCountLimit


### PR DESCRIPTION
These are the four excluded metrics that aren't available:
- `docker.container.memorySizeLimitBytes`
- `docker.container.memoryUsageLimitPercent`
- `docker.container.memorySwapLimitBytes`
- `docker.container.memorySwapLimitUsagePercent`

All of them are directly consumed from the [containerd library](https://github.com/containerd/cgroups/blob/188f73d13086fdfc4a26bdda70f0362203552e3a/v2/manager.go#L452), related to memory limits. IMHO it makes sense as the resource limitations has changed from cgroups v1 and v2, including the resource limitation feature on a container basis in v2.