### PR TITLE
Log a Warning in case there is a `nil` from Fargate

### DIFF
--- a/src/raw/aws/fargate_fetcher.go
+++ b/src/raw/aws/fargate_fetcher.go
@@ -50,8 +50,7 @@ func NewFargateFetcher(baseURL *url.URL) (*FargateFetcher, error) {
 
 // Fetch fetches raw metrics from a given Fargate container.
 func (e *FargateFetcher) Fetch(container docker.ContainerJSON) (raw.Metrics, error) {
-	var stats FargateStats
-	err := e.fargateStatsFromCacheOrNew(&stats)
+	stats, err := e.fargateStatsFromCacheOrNew()
 	if err != nil {
 		return raw.Metrics{}, err
 	}
@@ -63,23 +62,23 @@ func (e *FargateFetcher) Fetch(container docker.ContainerJSON) (raw.Metrics, err
 }
 
 // fargateStatsFromCacheOrNew wraps the access to Fargate task stats with a caching layer.
-func (e *FargateFetcher) fargateStatsFromCacheOrNew(response *FargateStats) error {
+func (e *FargateFetcher) fargateStatsFromCacheOrNew() (FargateStats, error) {
 	defer func() {
 		if err := e.containerStore.Save(); err != nil {
 			log.Warn("error persisting Fargate task metadata: %s", err)
 		}
 	}()
 
-	var err error
-	_, err = e.containerStore.Get(fargateTaskStatsCacheKey, response)
+	var response FargateStats
+	_, err := e.containerStore.Get(fargateTaskStatsCacheKey, &response)
 	if err == persist.ErrNotFound {
-		err = e.getFargateContainerMetrics(response)
+		response, err = e.getFargateContainerMetrics()
 	}
 	if err != nil {
-		return fmt.Errorf("cannot fetch task stats response: %s", err)
+		return nil, fmt.Errorf("cannot fetch task stats response: %s", err)
 	}
-	e.containerStore.Set(fargateTaskMetadataCacheKey, *response)
-	return nil
+	e.containerStore.Set(fargateTaskMetadataCacheKey, response)
+	return response, nil
 }
 
 // getFargateContainerMetrics returns Docker metrics from inside a Fargate container.
@@ -88,12 +87,12 @@ func (e *FargateFetcher) fargateStatsFromCacheOrNew(response *FargateStats) erro
 // Note that the endpoint doesn't follow strictly the same schema as Docker's: it returns a list of containers,
 // instead of only one. They are not compatible in terms of the requests that they accept, but they share
 // part of the response's schema.
-func (e *FargateFetcher) getFargateContainerMetrics(stats *FargateStats) error {
+func (e *FargateFetcher) getFargateContainerMetrics() (FargateStats, error) {
 	endpoint := TaskStatsEndpoint(e.baseURL.String())
 
 	response, err := metadataResponse(e.http, endpoint)
 	if err != nil {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"error when sending request to ECS container metadata endpoint (%s): %v",
 			endpoint,
 			err,
@@ -102,15 +101,20 @@ func (e *FargateFetcher) getFargateContainerMetrics(stats *FargateStats) error {
 	log.Debug("fargate task stats response from endpoint %s: %s", endpoint, string(response))
 	e.latestFetch = time.Now()
 
+	var stats FargateStats
 	err = json.Unmarshal(response, &stats)
 	if err != nil {
-		return fmt.Errorf("error unmarshalling ECS container: %v", err)
+		return nil, fmt.Errorf("error unmarshalling ECS container: %v", err)
 	}
 
 	now := time.Now()
-	for id := range *stats {
-		(*stats)[id].time = now
+	for i := range stats {
+		if stats[i] == nil {
+			log.Warn("getting stats from fargate returned a nil at index %d: %s", i, string(response))
+			continue
+		}
+		stats[i].time = now
 	}
 
-	return nil
+	return stats, nil
 }

--- a/src/raw/aws/fargate_fetcher.go
+++ b/src/raw/aws/fargate_fetcher.go
@@ -108,12 +108,13 @@ func (e *FargateFetcher) getFargateContainerMetrics() (FargateStats, error) {
 	}
 
 	now := time.Now()
-	for i := range stats {
-		if stats[i] == nil {
-			log.Warn("getting stats from fargate returned a nil at index %d: %s", i, string(response))
+	for i, k := range stats {
+		if k == nil {
+			log.Warn("getting stats from fargate returned a nil at index %d.", i)
+			log.Warn("raise the log level to debug to have more information")
 			continue
 		}
-		stats[i].time = now
+		k.time = now
 	}
 
 	return stats, nil


### PR DESCRIPTION
We have a ticket for a nil pointer dereference:

```
[WARN] computing Storage Driver stats: only devicemapper is supported
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x240 pc=0x7f5640]

goroutine 1 [running]:
github.com/newrelic/nri-docker/src/raw/aws.(*FargateFetcher).getFargateContainerMetrics(0xc4202ae880, 0xc42000e430, 0xc42028d480, 0x832901)
  /go/src/github.com/newrelic/nri-docker/src/raw/aws/fargate_fetcher.go:112 +0x4b0
github.com/newrelic/nri-docker/src/raw/aws.(*FargateFetcher).fargateStatsFromCacheOrNew(0xc4202ae880, 0xc42000e430, 0x0, 0x0)
  /go/src/github.com/newrelic/nri-docker/src/raw/aws/fargate_fetcher.go:76 +0x20a
github.com/newrelic/nri-docker/src/raw/aws.(*FargateFetcher).Fetch(0xc4202ae880, 0xc4200ab1e0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
  /go/src/github.com/newrelic/nri-docker/src/raw/aws/fargate_fetcher.go:54 +0x6a
github.com/newrelic/nri-docker/src/biz.(*MetricsFetcher).Process(0xc4202ae940, 0xc4202e2ae0, 0x2b, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
  /go/src/github.com/newrelic/nri-docker/src/biz/metrics.go:145 +0x1e4
github.com/newrelic/nri-docker/src/nri.(*ContainerSampler).SampleAll(0xc4201180c0, 0xb5f7a0, 0xc42001a018, 0xc4200a09a0, 0x0, 0x0)
  /go/src/github.com/newrelic/nri-docker/src/nri/sampler.go:89 +0x21c
main.main()
  /go/src/github.com/newrelic/nri-docker/src/docker.go:92 +0x647
```

This should fix the issue and warn us from where does this `nil` come from.