### PR TITLE
Remove attributes with empty values (NR-107455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.8.1  (2023-04-17)
+### Changed
+- Skip reporting container attributes with empty values (#152)
+
 ## 1.8.0  (2023-03-08)
 ### Changed
 - Bump dependencies

--- a/src/nri/sampler.go
+++ b/src/nri/sampler.go
@@ -165,11 +165,9 @@ func attributes(container types.Container) []entry {
 	// Removes attributes with emtpy values to avoid be reported.
 	sanitizedEntries := []entry{}
 	for _, entry := range entries {
-		if isAttributeValueEmpty(entry) {
-			continue
+                if !isAttributeValueEmpty(entry) {
+			sanitizedEntries = append(sanitizedEntries, entry)
 		}
-
-		sanitizedEntries = append(sanitizedEntries, entry)
 	}
 
 	return sanitizedEntries
@@ -177,10 +175,9 @@ func attributes(container types.Container) []entry {
 
 func isAttributeValueEmpty(e entry) bool {
 	if e.Type == metric.ATTRIBUTE {
-		if strVal, ok := e.Value.(string); ok && strVal == "" {
-			return true
-		}
-	}
+             strVal, ok := e.Value.(string)
+             return ok && strVal == ""
+        }
 	return false
 }
 

--- a/src/nri/sampler.go
+++ b/src/nri/sampler.go
@@ -138,9 +138,9 @@ func (cs *ContainerSampler) SampleAll(ctx context.Context, i *integration.Integr
 }
 
 func populate(ms *metric.Set, metrics []entry) {
-	for _, metric := range metrics {
-		if err := ms.SetMetric(metric.Name, metric.Value, metric.Type); err != nil {
-			log.Warn("Unexpected error setting metric %v: %v", metric, err)
+	for _, m := range metrics {
+		if err := ms.SetMetric(m.Name, m.Value, m.Type); err != nil {
+			log.Warn("Unexpected error setting metric %v: %v", m, err)
 		}
 	}
 }
@@ -153,7 +153,7 @@ func attributes(container types.Container) []entry {
 			cname = cname[1:]
 		}
 	}
-	return []entry{
+	entries := []entry{
 		metricCommandLine(container.Command),
 		metricContainerName(cname),
 		metricContainerImage(container.ImageID),
@@ -161,6 +161,27 @@ func attributes(container types.Container) []entry {
 		metricState(container.State),
 		metricStatus(container.Status),
 	}
+
+	// Removes attributes with emtpy values to avoid be reported.
+	sanitizedEntries := []entry{}
+	for _, entry := range entries {
+		if isAttributeValueEmpty(entry) {
+			continue
+		}
+
+		sanitizedEntries = append(sanitizedEntries, entry)
+	}
+
+	return sanitizedEntries
+}
+
+func isAttributeValueEmpty(e entry) bool {
+	if e.Type == metric.ATTRIBUTE {
+		if strVal, ok := e.Value.(string); ok && strVal == "" {
+			return true
+		}
+	}
+	return false
 }
 
 // labelRename contains a list of labels that should be

--- a/src/nri/sampler.go
+++ b/src/nri/sampler.go
@@ -165,7 +165,7 @@ func attributes(container types.Container) []entry {
 	// Removes attributes with emtpy values to avoid be reported.
 	sanitizedEntries := []entry{}
 	for _, entry := range entries {
-                if !isAttributeValueEmpty(entry) {
+		if !isAttributeValueEmpty(entry) {
 			sanitizedEntries = append(sanitizedEntries, entry)
 		}
 	}
@@ -175,9 +175,9 @@ func attributes(container types.Container) []entry {
 
 func isAttributeValueEmpty(e entry) bool {
 	if e.Type == metric.ATTRIBUTE {
-             strVal, ok := e.Value.(string)
-             return ok && strVal == ""
-        }
+		strVal, ok := e.Value.(string)
+		return ok && strVal == ""
+	}
 	return false
 }
 

--- a/src/nri/sampler_test.go
+++ b/src/nri/sampler_test.go
@@ -172,6 +172,7 @@ func TestSampleAll(t *testing.T) {
 			Names:   []string{"Container 1"},
 			Image:   "my_image",
 			ImageID: "my_image_id",
+			State:   "",
 		},
 	}, nil)
 	mocker.On("ContainerInspect", mock.Anything, mock.Anything).Return(types.ContainerJSON{
@@ -212,4 +213,7 @@ func TestSampleAll(t *testing.T) {
 	assert.Len(t, i.Entities, 1)
 	assert.Equal(t, i.Entities[0].Metadata.Name, "containerid")
 	assert.Equal(t, i.Entities[0].Metrics[0].Metrics["storageDataTotalBytes"], 102e9)
+
+	assert.Equal(t, i.Entities[0].Metrics[0].Metrics["image"], "my_image_id")
+	assert.NotContains(t, i.Entities[0].Metrics[0].Metrics, "state")
 }

--- a/src/nri/sampler_test.go
+++ b/src/nri/sampler_test.go
@@ -173,6 +173,10 @@ func TestSampleAll(t *testing.T) {
 			Image:   "my_image",
 			ImageID: "my_image_id",
 			State:   "",
+			Labels: map[string]string{
+				"value":   "foo",
+				"noValue": "",
+			},
 		},
 	}, nil)
 	mocker.On("ContainerInspect", mock.Anything, mock.Anything).Return(types.ContainerJSON{
@@ -215,5 +219,11 @@ func TestSampleAll(t *testing.T) {
 	assert.Equal(t, i.Entities[0].Metrics[0].Metrics["storageDataTotalBytes"], 102e9)
 
 	assert.Equal(t, i.Entities[0].Metrics[0].Metrics["image"], "my_image_id")
+	assert.Equal(t, i.Entities[0].Metrics[0].Metrics["label.value"], "foo")
+
+	// emtpy labels are populated
+	assert.Equal(t, i.Entities[0].Metrics[0].Metrics["label.noValue"], "")
+
+	// container attributes are not populated with emtpy values
 	assert.NotContains(t, i.Entities[0].Metrics[0].Metrics, "state")
 }


### PR DESCRIPTION
Depending on the source some of the attributes are not being populated, for instance in Fargate the `state` is not present on the metadata API. 

Currently the integration is sending this attributes with an empty value, this PR removes these attributes when the values is an empty string.

Note:
I studied the possibility to add this into the[ integration SDK](https://github.com/newrelic/infra-integrations-sdk/blob/v3.7.3/data/metric/metrics.go#L91) but since that func is returning an error it would be a breaking change, and also there might be a use case where empty values would make sense to be sent.