### PR TITLE
Revert actions using hash instead of tag

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout-repository
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v4
         with:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout-repository
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/on_prerelease.yml
+++ b/.github/workflows/on_prerelease.yml
@@ -19,7 +19,7 @@ jobs:
     name: Validate code via linters
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Validate code
         run: make ci/validate
 
@@ -27,7 +27,7 @@ jobs:
     name: Run unit tests on *Nix
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Unit tests
         run: make ci/test
 
@@ -40,7 +40,7 @@ jobs:
         working-directory: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
     steps:
       - name: Check out code
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate, test-nix, test-integration-nix]
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Pre release
         run: make ci/prerelease
         env:

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -17,7 +17,7 @@ jobs:
     name: Validate code via linters
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Validate code
         run: make ci/validate
       - name: Check if CHANGELOG is valid
@@ -27,7 +27,7 @@ jobs:
     name: Run unit tests on *Nix
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Unit tests
         run: make ci/test
 
@@ -40,7 +40,7 @@ jobs:
         working-directory: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
     steps:
       - name: Check out code
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           path: src/github.com/${{env.ORIGINAL_REPO_NAME}}
@@ -61,7 +61,7 @@ jobs:
         working-directory: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
     steps:
       - name: Check out code
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           path: src/github.com/${{env.ORIGINAL_REPO_NAME}}
@@ -78,6 +78,6 @@ jobs:
     name: Test binary compilation for all platforms:arch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Build all platforms:arch
         run: make ci/build

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -22,7 +22,7 @@ jobs:
             return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
       - name: Checkout Self
         if: ${{ steps.default-branch.outputs.result == 'true' }}
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
       - name: Run Repolinter
         if: ${{ steps.default-branch.outputs.result == 'true' }}
         uses: newrelic/repolinter-action@v1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
I misread the PRs from renovate and merged PRs that changed the tag to a commit hash.

We don't know if renovate will update commits written like that and if renovate might stick to master instead of following tag conventions.

As this is an untested territory I prefer to revert the change and keep working with tags.