### PR TITLE
Allow to set the cache TTL of storer (NR-179361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### Enhancement
+- Make metric cache used to calculate deltas configurable
+
 ## v1.8.29 - 2023-11-14
 
 ### ⛓️ Dependencies

--- a/src/biz/metrics.go
+++ b/src/biz/metrics.go
@@ -95,6 +95,11 @@ func NewProcessor(store persist.Storer, fetcher raw.Fetcher, inspector raw.Docke
 	}
 }
 
+// WithRuntimeNumCPUfunc changes the NumCPU counting func so MetricsFetcher is mockable
+func (mc *MetricsFetcher) WithRuntimeNumCPUfunc(rcFunc func() int) {
+	mc.getRuntimeNumCPU = rcFunc
+}
+
 // ErrExitedContainerExpired is the error type used when exited containers have exceed the TTL that would allow the
 // integration to keep reporting them.
 type ErrExitedContainerExpired struct {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -13,4 +13,6 @@ type ArgumentList struct {
 	// CgroupPath and CgroupDriver arguments are not used but are kept here for backwards compatibility reasons.
 	CgroupPath   string `default:"" help:"Deprecated. cgroup_path argument is not used anymore."`
 	CgroupDriver string `default:"" help:"Deprecated. cgroup_driver argument is not used anymore."`
+
+	CacheTTL string `default:"1m" help:"Set the maximum cache that the integration is going to use to calculate rates and deltas. Possible values are time-strings: 1s, 1m, 1h"`
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -14,5 +14,5 @@ type ArgumentList struct {
 	CgroupPath   string `default:"" help:"Deprecated. cgroup_path argument is not used anymore."`
 	CgroupDriver string `default:"" help:"Deprecated. cgroup_driver argument is not used anymore."`
 
-	CacheTTL string `default:"1m" help:"Set the maximum cache that the integration is going to use to calculate rates and deltas. Possible values are time-strings: 1s, 1m, 1h"`
+	CacheTTL string `default:"1m" help:"Set the maximum cache TTL that the integration is going to use to calculate rates and deltas. Possible values are time-strings: 1s, 1m, 1h"`
 }

--- a/src/docker.go
+++ b/src/docker.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/docker/docker/client"
 	"github.com/newrelic/infra-integrations-sdk/integration"
@@ -51,9 +50,6 @@ func main() {
 
 	log.SetupLogging(args.Verbose)
 
-	exitedContainerTTL, err := time.ParseDuration(args.ExitedContainersTTL)
-	exitOnErr(err)
-
 	var fetcher raw.Fetcher
 	var docker raw.DockerClient
 	if args.Fargate {
@@ -92,7 +88,7 @@ func main() {
 		)
 		exitOnErr(err)
 	}
-	sampler, err := nri.NewSampler(fetcher, docker, exitedContainerTTL, args)
+	sampler, err := nri.NewSampler(fetcher, docker, args)
 	exitOnErr(err)
 	exitOnErr(sampler.SampleAll(context.Background(), i))
 	exitOnErr(i.Publish())

--- a/src/nri/sampler.go
+++ b/src/nri/sampler.go
@@ -34,12 +34,22 @@ type ContainerSampler struct {
 }
 
 // NewSampler returns a ContainerSampler instance.
-func NewSampler(fetcher raw.Fetcher, docker raw.DockerClient, exitedContainerTTL time.Duration, config config.ArgumentList) (*ContainerSampler, error) {
+func NewSampler(fetcher raw.Fetcher, docker raw.DockerClient, config config.ArgumentList) (*ContainerSampler, error) {
+	cacheTTL, err := time.ParseDuration(config.CacheTTL)
+	if err != nil {
+		return nil, err
+	}
+
+	exitedContainerTTL, err := time.ParseDuration(config.ExitedContainersTTL)
+	if err != nil {
+		return nil, err
+	}
+
 	// SDK Storer to keep metric values between executions (e.g. for rates and deltas)
-	store, err := persist.NewFileStore( // TODO: make the following options configurable
+	store, err := persist.NewFileStore(
 		persist.DefaultPath("container_cpus"),
 		log.NewStdErr(true),
-		60*time.Second)
+		cacheTTL)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/metrics_cgroupsv2_test.go
+++ b/test/integration/metrics_cgroupsv2_test.go
@@ -94,6 +94,7 @@ func TestCgroupsv2AllMetricsPresent(t *testing.T) {
 
 	t.Run("Given a mockedFilesystem and previous CPU state Then processed metrics are as expected", func(t *testing.T) {
 		metrics := biz.NewProcessor(storer, cgroupFetcher, inspector, 0)
+		metrics.WithRuntimeNumCPUfunc(func() int { return 2 }) // Mocked cgroups are extracted from a 2 CPU machine.
 
 		sample, err := metrics.Process(InspectorContainerID)
 		require.NoError(t, err)


### PR DESCRIPTION
A customer states that is not able to see some CPU metrics if the interval is set to more than 1 minute.

These CPU Metrics that are failing rely on the storer to be able to calculate the delta/rate and the storer has hardcoded the value to 1 minute.

This PR allows the storer TTL to be variable for customers who might need it.