### PR TITLE
chore: use reusable workflows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,14 @@
 {
   "extends": [
     "github>newrelic/coreint-automation:renovate-base.json5"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        // Skip updating runners used to test cgroups v1
+        "ubuntu-20.04"
+      ],
+      "enabled": false
+    }
   ]
 }

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,8 +11,14 @@ jobs:
   e2eTests-cgroups-v1:
     # Do not run e2e tests if commit message or PR has skip-e2e.
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
+      - name: Check cgroups version
+        run: |
+          if [ $(docker info --format '{{.CgroupVersion}}') != "1" ]; then
+              echo "This test must be run in cgroups v1"
+              exit 1
+          fi
       - name: checkout-repository
         uses: actions/checkout@v4
       - name: Install Go

--- a/.github/workflows/on_prerelease.yaml
+++ b/.github/workflows/on_prerelease.yaml
@@ -7,104 +7,15 @@ on:
     tags:
       - 'v*'
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  INTEGRATION: "docker"
-  ORIGINAL_REPO_NAME: 'newrelic/nri-docker'
-  REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-  TAG: ${{ github.event.release.tag_name }}
-
 jobs:
-  validate:
-    name: Validate code via linters
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Validate code
-        run: make ci/validate
-
-  test-nix:
-    name: Run unit tests on *Nix
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Unit tests
-        run: make ci/test
-
-  # can't run this step inside of container because of tests specific
-  test-integration-nix:
-    name: Run integration tests on *Nix
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
-      - name: Install Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: 'src/github.com/${{ env.ORIGINAL_REPO_NAME }}/go.mod'
-      - name: Integration test
-        env:
-          GOPATH: ${{ github.workspace }}
-        run: make integration-test
-
-  prerelease:
-    name: Build binary for *Nix, create archives for *Nix, create packages for *Nix, upload all artifacts into GH Release assets
-    runs-on: ubuntu-latest
-    needs: [validate, test-nix, test-integration-nix]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Pre release
-        run: make ci/prerelease
-        env:
-          GPG_MAIL: 'infrastructure-eng@newrelic.com'
-          GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
-          GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
-
-  publish-to-s3:
-    name: Send release assets to S3
-    runs-on: ubuntu-latest
-    needs: [prerelease]
-    steps:
-      - name: Publish to S3 action
-        uses: newrelic/infrastructure-publish-action@v1
-        env:
-          AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
-          AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-staging"
-        with:
-          disable_lock: false
-          run_id: ${{ github.run_id }}
-          tag: ${{env.TAG}}
-          app_name: "nri-${{env.INTEGRATION}}"
-          repo_name: ${{ env.ORIGINAL_REPO_NAME }}
-          access_point_host: "staging"
-          schema: "custom"
-          schema_url: "https://raw.githubusercontent.com/newrelic/nri-docker/${{ env.TAG }}/build/s3-publish-schema.yml"
-          aws_region: "us-east-1"
-          aws_role_arn: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
-          aws_role_session_name: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
-          aws_access_key_id: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
-          aws_secret_access_key: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
-          aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
-          # used for locking in case of concurrent releases
-          aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
-          # used for signing package stuff
-          gpg_passphrase: ${{ secrets.OHAI_GPG_PASSPHRASE }}
-          gpg_private_key_base64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }}
-
-  notify-failure:
-    if: ${{ always() && failure() }}
-    needs: [validate, test-nix, test-integration-nix, prerelease, publish-to-s3]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify failure via Slack
-        uses: archive/github-actions-slack@master
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
-          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
-          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: [prerelease pipeline failed](${{ github.server_url }}/${{ env.ORIGINAL_REPO_NAME }}/actions/runs/${{ github.run_id }})."
+  pre-release:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_pre_release.yaml@v2
+    with:
+      tag: ${{ github.event.release.tag_name }}
+      integration: "docker"
+      test_package: false
+      run_test_windows: false
+      run_build-win-packages: false
+      publish_schema: custom
+      publish_schema_url: "https://raw.githubusercontent.com/newrelic/nri-docker/${{ github.event.release.tag_name }}/build/s3-publish-schema.yml"
+    secrets: inherit

--- a/.github/workflows/on_push_pr.yaml
+++ b/.github/workflows/on_push_pr.yaml
@@ -7,77 +7,26 @@ on:
       - renovate/**
   pull_request:
 
-env:
-  TAG: "v0.0.0" # not needed for go releaser, but kept for uniformity
-  REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-  ORIGINAL_REPO_NAME: "newrelic/nri-docker"
-
 jobs:
-  validate:
-    name: Validate code via linters
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Validate code
-        run: make ci/validate
-      - name: Check if CHANGELOG is valid
-        uses: newrelic/release-toolkit/validate-markdown@v1
+  push-pr:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_push_pr.yaml@v2
+    with:
+      run_test_windows: false
 
-  test-nix:
-    name: Run unit tests on *Nix
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Unit tests
-        run: make ci/test
-
-  # can't run this step inside of container because of tests specific
-  test-integration-nix:
+  test-integration-nix-cgroups-v1:
     name: Run integration tests on *Nix
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
+    needs: [push-pr]
+    runs-on: ubuntu-20.04
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          path: src/github.com/${{env.ORIGINAL_REPO_NAME}}
-      - name: Install Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: 'src/github.com/${{ env.ORIGINAL_REPO_NAME }}/go.mod'
-      - name: Integration test
-        env:
-          GOPATH: ${{ github.workspace }}
-        run: make integration-test
-
-  test-cgroups-v2-integration-nix:
-    name: Run integration tests for cgroups v2 on *Nix
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          path: src/github.com/${{env.ORIGINAL_REPO_NAME}}
-      - name: Install Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: 'src/github.com/${{ env.ORIGINAL_REPO_NAME }}/go.mod'
-      - name: Integration test
-        env:
-          GOPATH: ${{ github.workspace }}
-        run: make integration-test
-
-  test-build:
-    name: Test binary compilation for all platforms:arch
-    runs-on: ubuntu-latest
-    steps:
+      - name: Check cgroups version
+        run: |
+          if [ $(docker info --format '{{.CgroupVersion}}') != "1" ]; then
+              echo "This test must be run in cgroups v1"
+              exit 1
+          fi
       - uses: actions/checkout@v4
-      - name: Build all platforms:arch
-        run: make ci/build
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - name: Integration test
+        run: make integration-test


### PR DESCRIPTION
- Changes renovate config to skip bumping the runners used for cgroup v1 testing
- Adds reusable workflows 