### PR TITLE
fix renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,7 @@
     {
       "matchPackageNames": [
         // Skip updating runners used to test cgroups v1
-        "ubuntu-20.04"
+        "ubuntu"
       ],
       "enabled": false
     }


### PR DESCRIPTION
the package name is actually `ubuntu`

the idea is to avoid this bump https://github.com/newrelic/nri-docker/pull/198