### PR TITLE
NR-221180: docker api fetcher scaffolding

### DIFF
--- a/src/raw/client.go
+++ b/src/raw/client.go
@@ -24,6 +24,11 @@ type DockerClient interface {
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
 }
 
+// DockerStatsClient defines how to access docker container stats through the docker API.
+type DockerStatsClient interface {
+	ContainerStats(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error)
+}
+
 // CachedInfoDockerClient Wraps a DockerClient indefinitely caching Info method first call.
 type CachedInfoDockerClient struct {
 	DockerClient

--- a/src/raw/dockerapi/fetcher.go
+++ b/src/raw/dockerapi/fetcher.go
@@ -1,0 +1,72 @@
+package dockerapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/newrelic/nri-docker/src/raw"
+)
+
+type Fetcher struct {
+	statsClient raw.DockerStatsClient
+}
+
+func NewFetcher(statsClient raw.DockerStatsClient) *Fetcher {
+	return &Fetcher{statsClient: statsClient}
+}
+
+func (f *Fetcher) Fetch(container types.ContainerJSON) (raw.Metrics, error) {
+	containerStats, err := f.ContainerStats(context.Background(), container.ID)
+	if err != nil {
+		return raw.Metrics{}, fmt.Errorf("could not fetch stats for container %s: %w", container.ID, err)
+	}
+	now := time.Now() // nolint: staticcheck
+	metrics := raw.Metrics{
+		Time:        now,
+		ContainerID: container.ID,
+		Memory:      f.memoryMetrics(containerStats),
+		Network:     f.networkMetrics(containerStats),
+		CPU:         f.cpuMetrics(containerStats),
+		Pids:        f.pidsMetrics(containerStats),
+		Blkio:       f.blkioMetrics(containerStats),
+	}
+	return metrics, nil
+}
+
+func (f *Fetcher) memoryMetrics(containerStats types.StatsJSON) raw.Memory {
+	panic("unimplemented")
+}
+
+func (f *Fetcher) networkMetrics(containerStats types.StatsJSON) raw.Network {
+	panic("unimplemented")
+}
+
+func (f *Fetcher) cpuMetrics(containerStats types.StatsJSON) raw.CPU {
+	panic("unimplemented")
+}
+
+func (f *Fetcher) pidsMetrics(containerStats types.StatsJSON) raw.Pids {
+	panic("unimplemented")
+}
+
+func (f *Fetcher) blkioMetrics(containerStats types.StatsJSON) raw.Blkio {
+	panic("unimplemented")
+}
+
+// TODO: the helper below should be private when the corresponding fetcher is ready to be used.
+func (f *Fetcher) ContainerStats(ctx context.Context, containerID string) (types.StatsJSON, error) {
+	m, err := f.statsClient.ContainerStats(ctx, containerID, false)
+	if err != nil {
+		return types.StatsJSON{}, err
+	}
+	var statsJSON types.StatsJSON
+	err = json.NewDecoder(m.Body).Decode(&statsJSON)
+	m.Body.Close()
+	if err != nil {
+		return types.StatsJSON{}, err
+	}
+	return statsJSON, nil
+}

--- a/src/raw/dockerapi/fetcher.go
+++ b/src/raw/dockerapi/fetcher.go
@@ -23,9 +23,8 @@ func (f *Fetcher) Fetch(container types.ContainerJSON) (raw.Metrics, error) {
 	if err != nil {
 		return raw.Metrics{}, fmt.Errorf("could not fetch stats for container %s: %w", container.ID, err)
 	}
-	now := time.Now() // nolint: staticcheck
 	metrics := raw.Metrics{
-		Time:        now,
+		Time:        time.Now(), // nolint: staticcheck
 		ContainerID: container.ID,
 		Memory:      f.memoryMetrics(containerStats),
 		Network:     f.networkMetrics(containerStats),

--- a/test/integration/dockerapi_fetcher_test.go
+++ b/test/integration/dockerapi_fetcher_test.go
@@ -1,0 +1,39 @@
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/docker/docker/client"
+	"github.com/newrelic/nri-docker/src/raw/dockerapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerAPIHelpers(t *testing.T) {
+	// Build the client and the fetcher
+	// The API Version can be set up using `args.DockerClientVersion` (defaults to 1.24 for now)
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.24"))
+	require.NoError(t, err)
+	f := dockerapi.NewFetcher(dockerClient)
+
+	// run a container for testing purposes
+	containerID, dockerRM := stress(t, "stress-ng", "-c", "0", "-l", "0", "-t", "5m")
+	defer dockerRM()
+
+	// show container inspect data (it's done in biz/metrics)
+	inspectData, err := dockerClient.ContainerInspect(context.Background(), containerID)
+	require.NoError(t, err)
+	logAsJSON(t, "Inspect data", &inspectData)
+
+	// fetch stats data
+	statsData, err := f.ContainerStats(context.Background(), containerID)
+	require.NoError(t, err)
+	logAsJSON(t, "Container Stats", &statsData)
+}
+
+func logAsJSON(t *testing.T, title string, data any) {
+	b, err := json.Marshal(data)
+	require.NoError(t, err)
+	t.Logf("%s: %s", title, string(b))
+}

--- a/test/integration/dockerapi_fetcher_test.go
+++ b/test/integration/dockerapi_fetcher_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO: this should extended/replaced when the fetcher actually fetches something.
+// It currently it shows how to get container stats data and can be useful for development purposes.
 func TestDockerAPIHelpers(t *testing.T) {
 	// Build the client and the fetcher
 	// The API Version can be set up using `args.DockerClientVersion` (defaults to 1.24 for now)


### PR DESCRIPTION
## Docker API fetcher scaffolding

This PR introduces a new fetcher to get the metrics through the docker API. The fetcher is not used yet.

### Main changes
* The main function has been split to make it more readable and easier to extend.
* A new `DockerStatsClient` interface has been defined.
* A new package `raw.dockerapi` has been introduced, container the new fetcher scaffolding.
* A new temporal integration tests has been included: it shows how to build the new fetcher and how to fetch stats metrics from docker API. It can be used to quickly get docker container inspect and stats data in order to continue implementing the new fetcher.

### Notes for reviewers
* The new fetcher is not ready to be used (it includes some _unimplemented_ methods which would panic). However, since it is not used, the PR can be merged safely.
* Most metrics should come from `docker stats` but, if additional information was needed, the fetcher would be easy to extend.
* The `DockerAPIVersion` can be already configured using the integration arguments. The minimum required version and/or the default version might need to be adjusted in follow-up iterations (depending on the metrics needs).
* The new integration test was included for development purposes only, should be replaced by a proper integration test when the metrics are actually fetched.