### PR TITLE
extend docker-api integration test

### DIFF
--- a/test/integration/common.go
+++ b/test/integration/common.go
@@ -27,6 +27,9 @@ const (
 	pidsLimit          = "2000" // random limit for testing propouses
 	memLimitStr        = "100M"
 	memLimit           = 100 * 1024 * 1024 // 100 MB of memory
+	memReservationStr  = "95M"
+	memReservation     = 95 * 1024 * 1024 // 95MB of memory reservation
+	cpuShares          = 2048             // cpuShares value for testing purposes
 )
 
 var once sync.Once
@@ -53,8 +56,10 @@ func stress(t *testing.T, args ...string) (containerID string, closeFunc func())
 		"run", "-d",
 		"--name", containerName,
 		"--cpus", fmt.Sprint(cpus),
+		"--cpu-shares", fmt.Sprint(cpuShares),
 		"--memory", memLimitStr,
 		"--pids-limit", pidsLimit,
+		"--memory-reservation", memReservationStr,
 		imageTag}
 	arguments = append(arguments, args...)
 	cmd := exec.Command("docker", arguments...)

--- a/test/integration/dockerapi_fetcher_test.go
+++ b/test/integration/dockerapi_fetcher_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// It currently it shows how to get container stats data and can be useful for development purposes.
 func TestDockerAPIFetcher(t *testing.T) {
 	dockerClient := newDocker(t)
 
@@ -23,24 +22,49 @@ func TestDockerAPIFetcher(t *testing.T) {
 	fetcher := dockerapi.NewFetcher(dockerClient)
 
 	// run a container for testing purposes
-	containerID, dockerRM := stress(t, "stress-ng", "-c", "0", "-l", "0", "-t", "5m")
+	containerID, dockerRM := stress(t, "stress-ng", "-c", "2", "-l", "50", "-t", "5m", "--iomix", "10")
 	defer dockerRM()
 
-	// show container inspect data (it's done in biz/metrics)
 	inspectData, err := dockerClient.ContainerInspect(context.Background(), containerID)
 	require.NoError(t, err)
 
-	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 		statsData, err := fetcher.Fetch(inspectData)
-		require.NoError(t, err)
+		require.NoError(ct, err)
+
+		// CPU metrics
+		assert.NotZero(ct, statsData.CPU.TotalUsage)
+		assert.NotZero(ct, statsData.CPU.UsageInUsermode)
+		assert.NotZero(ct, statsData.CPU.UsageInKernelmode)
+		assert.NotZero(ct, statsData.CPU.SystemUsage)
+		assert.NotZero(ct, statsData.CPU.ThrottledPeriods)
+		assert.NotZero(ct, statsData.CPU.ThrottledTimeNS)
+		assert.NotZero(ct, statsData.CPU.OnlineCPUs)
+		assert.EqualValues(ct, cpuShares, statsData.CPU.Shares, "cpu-shares has been set, so it should be reported")
+
+		// Memory metrics
+		// SwapUsage cannot be fetched through docker API
+		assert.EqualValues(ct, statsData.Memory.UsageLimit, memLimit, "the memory limit has been set, so it should be reported")
+		assert.EqualValues(ct, statsData.Memory.SoftLimit, memReservation, "the memory soft limit has been set, so it should be reported")
+		assert.NotZero(ct, statsData.Memory.SwapLimit)
+		assert.NotZero(ct, statsData.Memory.Cache)
+		assert.NotZero(ct, statsData.Memory.RSS)
+		assert.NotZero(ct, statsData.Memory.KernelMemoryUsage)
 
 		// Network metrics
 		// Only RxBytes and RxPackets are generated
-		assert.NotZero(t, statsData.Network.RxBytes, "stress-ng should have generated RxBytes")
-		assert.NotZero(t, statsData.Network.RxPackets, "stress-ng should have generated RxPackets")
+		assert.NotZero(ct, statsData.Network.RxBytes, "stress-ng should have generated RxBytes")
+		assert.NotZero(ct, statsData.Network.RxPackets, "stress-ng should have generated RxPackets")
 
 		// Pids metrics
-		assert.Equal(t, pidsLimit, strconv.FormatUint(statsData.Pids.Limit, 10), "the limit has been set so it should be reported")
-		assert.NotZero(t, statsData.Pids.Current, "amount of processes or threads should be grater than 0")
+		assert.Equal(ct, pidsLimit, strconv.FormatUint(statsData.Pids.Limit, 10), "the limit has been set so it should be reported")
+		assert.NotZero(ct, statsData.Pids.Current, "amount of processes or threads should be grater than 0")
+		assert.NotZero(ct, statsData.Network.RxBytes)
+		assert.NotZero(ct, statsData.Network.RxPackets)
+
+		// Blkio metrics
+		// IoServicedRecursive can be empty if the io operations are not blocking
+		assert.NotEmpty(ct, statsData.Blkio.IoServiceBytesRecursive)
+
 	}, eventuallyTimeout, eventuallyTick)
 }

--- a/test/integration/dockerapi_fetcher_test.go
+++ b/test/integration/dockerapi_fetcher_test.go
@@ -59,8 +59,6 @@ func TestDockerAPIFetcher(t *testing.T) {
 		// Pids metrics
 		assert.Equal(ct, pidsLimit, strconv.FormatUint(statsData.Pids.Limit, 10), "the limit has been set so it should be reported")
 		assert.NotZero(ct, statsData.Pids.Current, "amount of processes or threads should be grater than 0")
-		assert.NotZero(ct, statsData.Network.RxBytes)
-		assert.NotZero(ct, statsData.Network.RxPackets)
 
 		// Blkio metrics
 		// IoServicedRecursive can be empty if the io operations are not blocking


### PR DESCRIPTION
Extend the integration tests of the docker-api fetcher to include CPU, Memory and Blkio metrics.