### PR TITLE
NR-231647: report only set blkio metrics, default to nil

### DIFF
--- a/src/biz/metrics.go
+++ b/src/biz/metrics.go
@@ -38,10 +38,10 @@ type Network raw.Network
 
 // BlkIO stands for Block I/O stats
 type BlkIO struct {
-	TotalReadCount  float64
-	TotalWriteCount float64
-	TotalReadBytes  float64
-	TotalWriteBytes float64
+	TotalReadCount  *float64
+	TotalWriteCount *float64
+	TotalReadBytes  *float64
+	TotalWriteBytes *float64
 }
 
 // CPU metrics
@@ -297,22 +297,36 @@ func (mc *MetricsFetcher) blkIO(blkio raw.Blkio) BlkIO {
 		if len(svc.Op) == 0 {
 			continue
 		}
+		var count = float64(svc.Value)
 		switch svc.Op[0] {
 		case 'r', 'R':
-			bio.TotalReadCount += float64(svc.Value)
+			if bio.TotalReadCount == nil {
+				bio.TotalReadCount = new(float64)
+			}
+			*bio.TotalReadCount += count
 		case 'w', 'W':
-			bio.TotalWriteCount += float64(svc.Value)
+			if bio.TotalWriteCount == nil {
+				bio.TotalWriteCount = new(float64)
+			}
+			*bio.TotalWriteCount += count
 		}
 	}
 	for _, bytes := range blkio.IoServiceBytesRecursive {
 		if len(bytes.Op) == 0 {
 			continue
 		}
+		var bCount = float64(bytes.Value)
 		switch bytes.Op[0] {
 		case 'r', 'R':
-			bio.TotalReadBytes += float64(bytes.Value)
+			if bio.TotalReadBytes == nil {
+				bio.TotalReadBytes = new(float64)
+			}
+			*bio.TotalReadBytes += bCount
 		case 'w', 'W':
-			bio.TotalWriteBytes += float64(bytes.Value)
+			if bio.TotalWriteBytes == nil {
+				bio.TotalWriteBytes = new(float64)
+			}
+			*bio.TotalWriteBytes += bCount
 		}
 	}
 	return bio

--- a/src/biz/metrics_aws_test.go
+++ b/src/biz/metrics_aws_test.go
@@ -43,10 +43,10 @@ func TestFargateMetrics(t *testing.T) {
 	assert.Equal(t, uint64(11), samples.Pids.Current)
 	assert.Equal(t, uint64(0), samples.Pids.Limit)
 
-	assert.Equal(t, float64(0), samples.BlkIO.TotalReadBytes)
-	assert.Equal(t, float64(0), samples.BlkIO.TotalReadCount)
-	assert.Equal(t, float64(7839744), samples.BlkIO.TotalWriteBytes)
-	assert.Equal(t, float64(957), samples.BlkIO.TotalWriteCount)
+	assert.Equal(t, float64(0), *samples.BlkIO.TotalReadBytes)
+	assert.Equal(t, float64(0), *samples.BlkIO.TotalReadCount)
+	assert.Equal(t, float64(7839744), *samples.BlkIO.TotalWriteBytes)
+	assert.Equal(t, float64(957), *samples.BlkIO.TotalWriteCount)
 
 	assert.Empty(t, samples.Network)
 }
@@ -76,10 +76,10 @@ func TestFargateMetricsV4(t *testing.T) {
 	assert.Equal(t, uint64(0x3), samples.Pids.Current)
 	assert.Equal(t, uint64(0), samples.Pids.Limit)
 
-	assert.Equal(t, float64(0), samples.BlkIO.TotalReadBytes)
-	assert.Equal(t, float64(0), samples.BlkIO.TotalReadCount)
-	assert.Equal(t, float64(0), samples.BlkIO.TotalWriteBytes)
-	assert.Equal(t, float64(0), samples.BlkIO.TotalWriteCount)
+	assert.Nil(t, samples.BlkIO.TotalReadBytes)
+	assert.Nil(t, samples.BlkIO.TotalReadCount)
+	assert.Nil(t, samples.BlkIO.TotalWriteBytes)
+	assert.Nil(t, samples.BlkIO.TotalWriteCount)
 
 	assert.Equal(t, int64(84), samples.Network.RxBytes)
 	assert.Equal(t, int64(0), samples.Network.RxDropped)
@@ -89,7 +89,6 @@ func TestFargateMetricsV4(t *testing.T) {
 	assert.Equal(t, int64(0), samples.Network.TxDropped)
 	assert.Equal(t, int64(3), samples.Network.TxErrors)
 	assert.Equal(t, int64(2), samples.Network.TxPackets)
-
 }
 
 func startMetadataEndpointStub(t *testing.T, taskID string) (server *httptest.Server, cleanup func()) {

--- a/src/nri/sampler.go
+++ b/src/nri/sampler.go
@@ -269,17 +269,33 @@ func pids(pids *biz.Pids) []entry {
 }
 
 func blkio(bio *biz.BlkIO) []entry {
-	return []entry{
-		metricIOTotalReadCount(bio.TotalReadCount),
-		metricIOTotalWriteCount(bio.TotalWriteCount),
-		metricIOTotalReadBytes(bio.TotalReadBytes),
-		metricIOTotalWriteBytes(bio.TotalWriteBytes),
-		metricIOTotalBytes(bio.TotalReadBytes + bio.TotalWriteBytes),
-		metricIOReadCountPerSecond(bio.TotalReadCount),
-		metricIOWriteCountPerSecond(bio.TotalWriteCount),
-		metricIOReadBytesPerSecond(bio.TotalReadBytes),
-		metricIOWriteBytesPerSecond(bio.TotalWriteBytes),
+	var entries []entry
+
+	if bio.TotalReadCount != nil {
+		entries = append(entries, metricIOTotalReadCount(bio.TotalReadCount), metricIOReadCountPerSecond(bio.TotalReadCount))
 	}
+	if bio.TotalWriteCount != nil {
+		entries = append(entries, metricIOTotalWriteCount(bio.TotalWriteCount), metricIOWriteCountPerSecond(bio.TotalWriteCount))
+	}
+	if bio.TotalReadBytes != nil {
+		entries = append(entries, metricIOTotalReadBytes(bio.TotalReadBytes), metricIOReadBytesPerSecond(bio.TotalReadBytes))
+	}
+	if bio.TotalWriteBytes != nil {
+		entries = append(entries, metricIOTotalWriteBytes(bio.TotalWriteBytes), metricIOWriteBytesPerSecond(bio.TotalWriteBytes))
+	}
+
+	if bio.TotalReadBytes != nil || bio.TotalWriteBytes != nil {
+		totalBytes := 0.0
+		if bio.TotalReadBytes != nil {
+			totalBytes += *bio.TotalReadBytes
+		}
+		if bio.TotalWriteBytes != nil {
+			totalBytes += *bio.TotalWriteBytes
+		}
+		entries = append(entries, metricIOTotalBytes(totalBytes))
+	}
+
+	return entries
 }
 
 func (cs *ContainerSampler) networkMetrics(net *biz.Network) []entry {

--- a/test/integration/common.go
+++ b/test/integration/common.go
@@ -83,3 +83,7 @@ func stress(t *testing.T, args ...string) (containerID string, closeFunc func())
 		}
 	}
 }
+
+func float64ToPointer(f float64) *float64 {
+	return &f
+}

--- a/test/integration/metrics_cgroupsv2_test.go
+++ b/test/integration/metrics_cgroupsv2_test.go
@@ -36,10 +36,10 @@ func TestCgroupsv2AllMetricsPresent(t *testing.T) {
 			TxPackets: 3,
 		},
 		BlkIO: biz.BlkIO{
-			TotalReadCount:  14203,
-			TotalWriteCount: 40554,
-			TotalReadBytes:  135932,
-			TotalWriteBytes: 207296,
+			TotalReadCount:  float64ToPointer(14203),
+			TotalWriteCount: float64ToPointer(40554),
+			TotalReadBytes:  float64ToPointer(135932),
+			TotalWriteBytes: float64ToPointer(207296),
 		},
 		CPU: biz.CPU{
 			CPUPercent:       191.3611027027027,

--- a/test/integration/mocks.go
+++ b/test/integration/mocks.go
@@ -1,11 +1,15 @@
 package integration
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/newrelic/nri-docker/src/raw"
+	"github.com/stretchr/testify/mock"
 )
 
 const cgroupDriver = "systemd"
@@ -122,4 +126,18 @@ func (i InspectorMock) ContainerInspect(_ context.Context, _ string) (types.Cont
 
 func (i InspectorMock) Info(_ context.Context) (types.Info, error) {
 	return types.Info{}, nil
+}
+
+type mockDockerStatsClient struct {
+	mock.Mock
+}
+
+func (m *mockDockerStatsClient) ContainerStats(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error) {
+	args := m.Called()
+
+	statsJSON, _ := json.Marshal(args.Get(0).(types.StatsJSON))
+
+	return types.ContainerStats{
+		Body: io.NopCloser(bytes.NewReader(statsJSON)),
+	}, nil
 }


### PR DESCRIPTION
This PR updates the logic to only report blkio metrics that are explicitly set, defaulting to nil for any metrics that are not.