### PR TITLE
[NR-286408] chore: update docker compose command

### DIFF
--- a/test/e2e/e2e_spec.yml
+++ b/test/e2e/e2e_spec.yml
@@ -5,9 +5,9 @@ scenarios:
   - description: |
       This scenario will verify that metrics from docker integration are correcly collected.
     before:
-      - docker-compose up -d
+      - docker compose up -d
     after:
-      - docker-compose down -v
+      - docker compose down -v
     integrations:
       - name: nri-docker
         binary_path: ../../bin/nri-docker


### PR DESCRIPTION
`docker-compose` v1 is EOL, and we need to move to `docker compose` (wit a space).