### PR TITLE
[NR-231640] fix: fetch SofLimitBytes from docker inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### Bugfix
+- Fetch the `SoftLimitBytes` metric from docker inspect for cgroups-v2.
+
 ## v2.0.7 - 2024-08-06
 
 ### ⛓️ Dependencies

--- a/test/integration/metrics_cgroupsv2_test.go
+++ b/test/integration/metrics_cgroupsv2_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types/container"
 	"github.com/newrelic/nri-docker/src/biz"
 	"github.com/newrelic/nri-docker/src/raw"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,7 @@ import (
 const (
 	InspectorPIDCgroupsV2                     = 667
 	relativePathToTestdataFilesystemCgroupsV2 = "testdata/cgroupsV2_host/"
+	memoryReservationValue                    = 104857600
 )
 
 func TestCgroupsv2AllMetricsPresent(t *testing.T) {
@@ -63,7 +65,7 @@ func TestCgroupsv2AllMetricsPresent(t *testing.T) {
 			SwapOnlyUsageBytes:    uint64ToPointer(18446744073274032228),
 			SwapLimitBytes:        0,
 			SwapLimitUsagePercent: float64ToPointer(0),
-			SoftLimitBytes:        2,
+			SoftLimitBytes:        104857600,
 		},
 		RestartCount: 2,
 	}
@@ -86,7 +88,9 @@ func TestCgroupsv2AllMetricsPresent(t *testing.T) {
 	}
 	storer := inMemoryStorerWithCustomPreviousCPUState(previousCPUState)
 
-	inspector := NewInspectorMock(InspectorContainerID, InspectorPIDCgroupsV2, 2)
+	hostConfig := &container.HostConfig{}
+	hostConfig.MemoryReservation = memoryReservationValue
+	inspector := NewInspectorMock(InspectorContainerID, InspectorPIDCgroupsV2, 2, hostConfig)
 
 	currentSystemUsage := 75 * 1e9 // seconds in ns
 	cgroupFetcher, err := NewCgroupsV2FetcherMock(hostRoot, mockedTimeForAllMetricsTest, uint64(currentSystemUsage))

--- a/test/integration/metrics_test.go
+++ b/test/integration/metrics_test.go
@@ -73,7 +73,6 @@ func TestCompareMetrics(t *testing.T) {
 			log.Error("sampleCGroup: %q", string(data))
 
 			// TODO this comparisons should be enabled back as soon as they are fixed for cgroupsV2
-			// assert.InDelta(t, sampleCGroup.Memory.SoftLimitBytes, sampleAPI.Memory.SoftLimitBytes, 50000, "SoftLimitBytes")
 			// assert.InDelta(t, sampleCGroup.CPU.Shares, sampleAPI.CPU.Shares, 200, "Shares")
 
 			// These metrics are not available for fargate and through the DockerAPI
@@ -84,11 +83,11 @@ func TestCompareMetrics(t *testing.T) {
 			// assert.InDelta(t, sampleCGroup.Memory.SwapUsageBytes, sampleAPI.Memory.SwapUsageBytes, 5000000, "SwapUsageBytes")
 
 			assert.InDelta(t, sampleCGroup.Memory.UsagePercent, sampleAPI.Memory.UsagePercent, 2, "UsagePercent")
-			assert.InDelta(t, sampleCGroup.Memory.UsagePercent, sampleAPI.Memory.UsagePercent, 2, "UsagePercent")
 			assert.InDelta(t, sampleCGroup.Memory.KernelUsageBytes, sampleAPI.Memory.KernelUsageBytes, 5000000, "KernelUsageBytes")
 			assert.InDelta(t, sampleCGroup.Memory.RSSUsageBytes, sampleAPI.Memory.RSSUsageBytes, 5000000, "RSSUsageBytes")
 			assert.InDelta(t, sampleCGroup.Memory.UsageBytes, sampleAPI.Memory.UsageBytes, 5000000, "UsageBytes")
 			assert.InDelta(t, sampleCGroup.Memory.MemLimitBytes, sampleAPI.Memory.MemLimitBytes, 5000000, "MemLimitBytes")
+			assert.Equal(t, sampleCGroup.Memory.SoftLimitBytes, sampleAPI.Memory.SoftLimitBytes, "SoftLimitBytes")
 
 			assert.InDelta(t, sampleCGroup.CPU.KernelPercent, sampleAPI.CPU.KernelPercent, 3, "KernelPercent")
 			assert.InDelta(t, sampleCGroup.CPU.UserPercent, sampleAPI.CPU.UserPercent, 3, "UserPercent")
@@ -356,7 +355,7 @@ func TestAllMetricsPresent(t *testing.T) {
 	require.NoError(t, err)
 
 	storer := inMemoryStorerWithPreviousCPUState()
-	inspector := NewInspectorMock(InspectorContainerID, InspectorPID, 2)
+	inspector := NewInspectorMock(InspectorContainerID, InspectorPID, 2, nil)
 
 	t.Run("Given a mockedFilesystem and previous CPU state Then processed metrics are as expected", func(t *testing.T) {
 		metrics := biz.NewProcessor(storer, cgroupFetcher, inspector, 0)
@@ -440,7 +439,7 @@ func TestBlkIOMetrics(t *testing.T) {
 			dockerAPIFetcher := dockerapi.NewFetcher(&client)
 
 			storer := inMemoryStorerWithPreviousCPUState()
-			inspector := NewInspectorMock(InspectorContainerID, InspectorPID, 2)
+			inspector := NewInspectorMock(InspectorContainerID, InspectorPID, 2, nil)
 
 			metrics := biz.NewProcessor(storer, dockerAPIFetcher, inspector, 0)
 

--- a/test/integration/mocks.go
+++ b/test/integration/mocks.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/system"
 	"github.com/newrelic/nri-docker/src/raw"
 	"github.com/stretchr/testify/mock"
@@ -103,13 +104,15 @@ type InspectorMock struct {
 	containerID  string
 	pid          int
 	restartCount int
+	hostConfig   *container.HostConfig
 }
 
-func NewInspectorMock(containerID string, pid, restartCount int) InspectorMock {
+func NewInspectorMock(containerID string, pid, restartCount int, hostConfig *container.HostConfig) InspectorMock {
 	return InspectorMock{
 		containerID:  containerID,
 		pid:          pid,
 		restartCount: restartCount,
+		hostConfig:   hostConfig,
 	}
 }
 
@@ -121,6 +124,7 @@ func (i InspectorMock) ContainerInspect(_ context.Context, _ string) (types.Cont
 				Pid: i.pid,
 			},
 			RestartCount: i.restartCount,
+			HostConfig:   i.hostConfig,
 		},
 	}, nil
 }


### PR DESCRIPTION
`SoftLimitBytes` metric values was being fetched from `low` value in `memory.events` instead of `memory.low` (check [cgroups-v2 specs](https://git.kernel.org/pub/scm/linux/kernel/git/tj/cgroup.git/tree/Documentation/admin-guide/cgroup-v2.rst) for details).

Since the corresponding value is in the response of `docker inspect` (which is called in a previous step), this PR updates the cgroups-v2 fetcher to get it from there.