### PR TITLE
[NR-231645] fix: fetch cpuShares from docker inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ### Bugfix
 - Fetch the `SoftLimitBytes` metric from docker inspect for cgroups-v2.
+- Fetch the `CPUShares` metric from docker inspect for cgroups-v2.
 
 ## v2.0.7 - 2024-08-06
 

--- a/src/raw/cgroupv2.go
+++ b/src/raw/cgroupv2.go
@@ -72,8 +72,10 @@ func (cg *CgroupsV2Fetcher) Fetch(containerInfo types.ContainerJSON) (Metrics, e
 		log.Error("couldn't read cpu stats: %v", err)
 	}
 
-	if stats.CPU.Shares, err = cgroupInfo.getSingleFileUintStat("cpu.weight"); err != nil {
-		log.Error("couldn't read cpu weight: %v", err)
+	if containerInfo.HostConfig != nil {
+		stats.CPU.Shares = uint64(containerInfo.HostConfig.CPUShares)
+	} else {
+		log.Debug("CPUShares metric could not be fetched for container %q because host configuration is not available")
 	}
 
 	cpusetPath := filepath.Join(cgroupInfo.getFullPath(), "cpuset.cpus.effective")

--- a/test/integration/metrics_cgroupsv2_test.go
+++ b/test/integration/metrics_cgroupsv2_test.go
@@ -19,6 +19,7 @@ const (
 	InspectorPIDCgroupsV2                     = 667
 	relativePathToTestdataFilesystemCgroupsV2 = "testdata/cgroupsV2_host/"
 	memoryReservationValue                    = 104857600
+	cpuSharesValue                            = 2048
 )
 
 func TestCgroupsv2AllMetricsPresent(t *testing.T) {
@@ -52,7 +53,7 @@ func TestCgroupsv2AllMetricsPresent(t *testing.T) {
 			UsedCoresPercent: 177.00902,
 			ThrottlePeriods:  0,
 			ThrottledTimeMS:  0,
-			Shares:           100,
+			Shares:           2048,
 		},
 		Memory: biz.Memory{
 			UsageBytes:            141561856,
@@ -90,6 +91,7 @@ func TestCgroupsv2AllMetricsPresent(t *testing.T) {
 
 	hostConfig := &container.HostConfig{}
 	hostConfig.MemoryReservation = memoryReservationValue
+	hostConfig.CPUShares = cpuSharesValue
 	inspector := NewInspectorMock(InspectorContainerID, InspectorPIDCgroupsV2, 2, hostConfig)
 
 	currentSystemUsage := 75 * 1e9 // seconds in ns

--- a/test/integration/metrics_test.go
+++ b/test/integration/metrics_test.go
@@ -73,7 +73,6 @@ func TestCompareMetrics(t *testing.T) {
 			log.Error("sampleCGroup: %q", string(data))
 
 			// TODO this comparisons should be enabled back as soon as they are fixed for cgroupsV2
-			// assert.InDelta(t, sampleCGroup.CPU.Shares, sampleAPI.CPU.Shares, 200, "Shares")
 
 			// These metrics are not available for fargate and through the DockerAPI
 			// assert.InDelta(t, sampleCGroup.Memory.SwapOnlyUsageBytes, sampleAPI.Memory.SwapOnlyUsageBytes, 50000, "SwapOnlyUsageBytes")
@@ -88,6 +87,7 @@ func TestCompareMetrics(t *testing.T) {
 			assert.InDelta(t, sampleCGroup.Memory.UsageBytes, sampleAPI.Memory.UsageBytes, 5000000, "UsageBytes")
 			assert.InDelta(t, sampleCGroup.Memory.MemLimitBytes, sampleAPI.Memory.MemLimitBytes, 5000000, "MemLimitBytes")
 			assert.Equal(t, sampleCGroup.Memory.SoftLimitBytes, sampleAPI.Memory.SoftLimitBytes, "SoftLimitBytes")
+			assert.Equal(t, sampleCGroup.CPU.Shares, sampleAPI.CPU.Shares, "CPUShares")
 
 			assert.InDelta(t, sampleCGroup.CPU.KernelPercent, sampleAPI.CPU.KernelPercent, 3, "KernelPercent")
 			assert.InDelta(t, sampleCGroup.CPU.UserPercent, sampleAPI.CPU.UserPercent, 3, "UserPercent")


### PR DESCRIPTION
The integration is currently reporting `cpu.weight` from cgroups-v2 as the value for `CPUShares` metric. This is a bit misleading because, even if the meaning of `cpu.weight` according to the [cgroups-v2 spec](https://git.kernel.org/pub/scm/linux/kernel/git/tj/cgroup.git/tree/Documentation/admin-guide/cgroup-v2.rst#:~:text=nr_bursts%0A%09%2D%20burst_usec-,cpu.weight,-A%20read%2Dwrite) is the same as `cpu-shares` in [docker's runtime options](https://docs.docker.com/engine/containers/resource_constraints/#cpu), the scale is different.

**cpu.weigh**:
>	A read-write single value file which exists on non-root
>	cgroups.  The default is "100".
>
>	For non idle groups (cpu.idle = 0), the weight is in the
>	range [1, 10000].
>
>	If the cgroup has been configured to be SCHED_IDLE (cpu.idle = 1),
>	then the weight will show as a 0.

**cpu-shares**:

> Set this flag to a value greater or less than the default of 1024 to increase or reduce the container's weight, and give it access to a greater or lesser proportion of the host machine's CPU cycles. This is only enforced when CPU cycles are constrained. When plenty of CPU cycles are available, all containers use as much CPU as they need. In that way, this is a soft limit. --cpu-shares doesn't prevent containers from being scheduled in Swarm mode. It prioritizes container CPU resources for the available CPU cycles. It doesn't guarantee or reserve any specific CPU access.

Therefore, this PR updates the way of fetching `CPUShares` to set the value coming from the `docker inspect` (since the request is performed in a previous step).

There is an alternative approach of computing the cgroups-v1 value from the cgroups-v2 `cpu.weight` (check out [this function](https://github.com/opencontainers/runc/blob/d5e4c33001d74176222fe8f48a323f3e8ad89999/libcontainer/cgroups/utils.go#L404) from runc for details), but getting the value from the inspect response is simpler. Besides, this approach is less error-prone since the value reported is the very same that is set when using Docker's `--cpu-shares` option.
