### PR TITLE
add fips compliant package builds

### DIFF
--- a/.github/workflows/on_prerelease.yaml
+++ b/.github/workflows/on_prerelease.yaml
@@ -17,6 +17,6 @@ jobs:
       run_test_windows: false
       run_build-win-packages: false
       publish_schema: custom
-      dest_prefix: "infrastructure_agent/"
+      dest_prefix: "infrastructure_agent/" # path prefix where the artifacts will be stored in the S3 bucket (use for testing)
       publish_schema_url: "https://raw.githubusercontent.com/newrelic/nri-docker/${{ github.event.release.tag_name }}/build/s3-publish-schema.yml"
     secrets: inherit

--- a/.github/workflows/on_prerelease.yaml
+++ b/.github/workflows/on_prerelease.yaml
@@ -17,5 +17,6 @@ jobs:
       run_test_windows: false
       run_build-win-packages: false
       publish_schema: custom
+      dest_prefix: "infrastructure_agent/"
       publish_schema_url: "https://raw.githubusercontent.com/newrelic/nri-docker/${{ github.event.release.tag_name }}/build/s3-publish-schema.yml"
     secrets: inherit

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -1,3 +1,6 @@
+---
+version: 2
+project_name: nri-docker
 builds:
   - id: nri-nix
     main: ./src
@@ -13,12 +16,38 @@ builds:
       - amd64
       - arm
       - arm64
-
+  - id: nri-nix-fips
+    main: ./src
+    binary: nri-docker
+    ldflags:
+      - -s -w -X main.integrationVersion={{.Version}} -X main.gitCommit={{.Commit}} -X main.buildDate={{.Date}}
+    env:
+      - CGO_ENABLED=1
+      - GOEXPERIMENT=boringcrypto
+      - >-
+        {{- if eq .Arch "arm64" -}}
+        CC=aarch64-linux-gnu-gcc
+        {{- end }}
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    tags:
+      - fips
 archives:
   - id: nri-nix
     builds:
       - nri-nix
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Version }}_{{ .Arch }}_dirty"
+    files:
+      - docker-config.yml
+      - docker-definition.yml
+    format: tar.gz
+  - id: nri-nix-fips
+    builds:
+      - nri-nix-fips
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Version }}_{{ .Arch }}_fips_dirty"
     files:
       - docker-config.yml
       - docker-definition.yml

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,15 +1,46 @@
-FROM golang:1.23.2-bookworm
+# Use Ubuntu 16.04 as the base image
+FROM ubuntu:16.04
 
-ARG GH_VERSION='2.23.0'
+# Define Go version
+ARG GO_VERSION=1.23.2
+ARG ARCH='amd64'
+ARG GH_VERSION='2.61.0'
 
-RUN apt-get update \
-    && apt-get -y install \
-        rpm \
-        gnupg2 \
-        gpg-agent \
-        debsigs \
-        unzip \
-        zip
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    gnupg-agent \
+    unzip \
+    zip \
+    curl \
+    wget \
+    expect \
+    git \
+    tar \
+    gcc \
+    jq \
+    g++ \
+    gnupg2 \
+    gnupg-agent \
+    debsigs \
+    rpm \
+    build-essential \
+    software-properties-common \
+    python-software-properties \
+    gcc-arm-linux-gnueabi \
+    dpkg-sig \
+    gcc-aarch64-linux-gnu
+
+# Install Go
+RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz -o go${GO_VERSION}.linux-${ARCH}.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-${ARCH}.tar.gz && \
+    rm go${GO_VERSION}.linux-${ARCH}.tar.gz
+
+# Set Go environment variables
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH="/go"
+
+# Optional: Set Go environment flags
+ENV GOFLAGS="-buildvcs=false"
 
 # Since the user does not match the owners of the repo "git rev-parse --is-inside-work-tree" fails and goreleaser does not populate projectName
 # https://stackoverflow.com/questions/72978485/git-submodule-update-failed-with-fatal-detected-dubious-ownership-in-repositor

--- a/build/release.mk
+++ b/build/release.mk
@@ -1,5 +1,5 @@
 BUILD_DIR    := ./bin/
-GORELEASER_VERSION := v0.172.1
+GORELEASER_VERSION := v2.4.4
 GORELEASER_BIN ?= bin/goreleaser
 
 bin:
@@ -27,10 +27,10 @@ release/deps: $(GORELEASER_BIN)
 release/build: release/deps release/clean
 ifeq ($(PRERELEASE), true)
 	@echo "===> $(INTEGRATION) === [release/build] PRE-RELEASE compiling all binaries, creating packages, archives"
-	@$(GORELEASER_BIN) release --config $(CURDIR)/build/.goreleaser.yml --rm-dist
+	@$(GORELEASER_BIN) release --config $(CURDIR)/build/.goreleaser.yml --clean
 else
 	@echo "===> $(INTEGRATION) === [release/build] build compiling all binaries"
-	@$(GORELEASER_BIN) build --config $(CURDIR)/build/.goreleaser.yml --snapshot --rm-dist
+	@$(GORELEASER_BIN) build --config $(CURDIR)/build/.goreleaser.yml --snapshot --clean
 endif
 
 .PHONY : release/fix-archive

--- a/build/s3-publish-schema.yml
+++ b/build/s3-publish-schema.yml
@@ -11,3 +11,11 @@
     - 386
     - arm
     - arm64
+
+- src: "{app_name}_linux_{version}_{arch}_fips.tar.gz"
+  uploads:
+    - type: file
+      dest: "{dest_prefix}binaries/linux/{arch}/{src}"
+  arch:
+    - amd64
+    - arm64

--- a/src/fips.go
+++ b/src/fips.go
@@ -1,0 +1,11 @@
+// Copyright 2024 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build fips
+// +build fips
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)


### PR DESCRIPTION
### Changes
* update goreleaser version
* add fips compliant package building
* update renovate config to update go version in Dockerfile builds

### Testing
[test s3 package for prerelease](http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/rohan-fips-test/)
`goreleaser` output with local testing:
```log
root@b6b613dee1a0:/app# bin/goreleaser release --config ./build/.goreleaser.yml --clean
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=cb94086849408cb78901684dd57b1556f34339b3 branch=NR-287144-build-fips-compliant-packages current_tag=v2.1.0 previous_tag=v2.0.9 dirty=false
  ⨯ release failed after 0s                          error=git tag v2.1.0 was not made against commit cb94086849408cb78901684dd57b1556f34339b3
root@b6b613dee1a0:/app# bin/goreleaser release --config ./build/.goreleaser.yml --clean --snapshot
  • skipping announce, publish and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=cb94086849408cb78901684dd57b1556f34339b3 branch=NR-287144-build-fips-compliant-packages current_tag=v2.1.0 previous_tag=v2.0.9 dirty=false
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • pipe skipped                                   reason=release is disabled
  • snapshotting
    • building snapshot...                           version=2.1.0-SNAPSHOT-cb94086
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/nri-nix_linux_arm_6/nri-docker
    • building                                       binary=dist/nri-nix_linux_amd64_v1/nri-docker
    • building                                       binary=dist/nri-nix_linux_arm64_v8.0/nri-docker
    • building                                       binary=dist/nri-nix_linux_386_sse2/nri-docker
    • building                                       binary=dist/nri-nix-fips_linux_arm64_v8.0/nri-docker
    • building                                       binary=dist/nri-nix-fips_linux_amd64_v1/nri-docker
    • took: 1m27s
  • archives
    • creating                                       archive=dist/nri-docker_linux_2.1.0-SNAPSHOT-cb94086_amd64_fips_dirty.tar.gz
    • creating                                       archive=dist/nri-docker_linux_2.1.0-SNAPSHOT-cb94086_arm64_dirty.tar.gz
    • creating                                       archive=dist/nri-docker_linux_2.1.0-SNAPSHOT-cb94086_arm_dirty.tar.gz
    • creating                                       archive=dist/nri-docker_linux_2.1.0-SNAPSHOT-cb94086_arm64_fips_dirty.tar.gz
    • creating                                       archive=dist/nri-docker_linux_2.1.0-SNAPSHOT-cb94086_amd64_dirty.tar.gz
    • creating                                       archive=dist/nri-docker_linux_2.1.0-SNAPSHOT-cb94086_386_dirty.tar.gz
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 1m30s
  • thanks for using goreleaser!
```
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/d4a3ebd2-4e3c-4815-939d-abf97fa385db">
