### PR TITLE
Fix fips pkg names

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -47,7 +47,7 @@ archives:
   - id: nri-nix-fips
     builds:
       - nri-nix-fips
-    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Version }}_{{ .Arch }}_fips_dirty"
+    name_template: "{{ .ProjectName }}-fips_{{ .Os }}_{{ .Version }}_{{ .Arch }}_dirty"
     files:
       - docker-config.yml
       - docker-definition.yml

--- a/build/s3-publish-schema.yml
+++ b/build/s3-publish-schema.yml
@@ -12,7 +12,7 @@
     - arm
     - arm64
 
-- src: "{app_name}_linux_{version}_{arch}_fips.tar.gz"
+- src: "{app_name}-fips_linux_{version}_{arch}.tar.gz"
   uploads:
     - type: file
       dest: "{dest_prefix}binaries/linux/{arch}/{src}"


### PR DESCRIPTION
To be consistent with other OHIs package names for `apt` and `zypper`, updating package names for `nri-docker`.