### PR TITLE
feat(windows): add platform as a member to decide os specific metrics

### DIFF
--- a/src/constants/constants.go
+++ b/src/constants/constants.go
@@ -1,0 +1,7 @@
+package constants
+
+const (
+	LinuxPlatformName   = "linux"
+	WindowsPlatformName = "windows"
+	DarwinPlatformName  = "darwin"
+)

--- a/src/raw/dockerapi/fetcher.go
+++ b/src/raw/dockerapi/fetcher.go
@@ -14,10 +14,11 @@ import (
 
 type Fetcher struct {
 	statsClient raw.DockerStatsClient
+	platform    string
 }
 
-func NewFetcher(statsClient raw.DockerStatsClient) *Fetcher {
-	return &Fetcher{statsClient: statsClient}
+func NewFetcher(statsClient raw.DockerStatsClient, platform string) *Fetcher {
+	return &Fetcher{statsClient: statsClient, platform: platform}
 }
 
 func (f *Fetcher) Fetch(container types.ContainerJSON) (raw.Metrics, error) {

--- a/src/raw/dockerapi/fetcher_test.go
+++ b/src/raw/dockerapi/fetcher_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/newrelic/nri-docker/src/constants"
 	"github.com/newrelic/nri-docker/src/raw"
 	"github.com/newrelic/nri-docker/src/raw/dockerapi"
 	"github.com/stretchr/testify/assert"
@@ -101,7 +102,7 @@ func Test_Fetch(t *testing.T) {
 	client := mockDockerStatsClient{}
 	client.On("ContainerStats", mock.Anything).Return(mockStats)
 
-	fetcher := dockerapi.NewFetcher(&client)
+	fetcher := dockerapi.NewFetcher(&client, constants.LinuxPlatformName)
 
 	metrics, err := fetcher.Fetch(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{
 		ID: "test",
@@ -195,7 +196,7 @@ func Test_NilHostConfig(t *testing.T) {
 	client := mockDockerStatsClient{}
 	client.On("ContainerStats", mock.Anything).Return(mockStats)
 
-	fetcher := dockerapi.NewFetcher(&client)
+	fetcher := dockerapi.NewFetcher(&client, constants.LinuxPlatformName)
 
 	metricsNoHostConfig, err := fetcher.Fetch(types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{ID: "test"}})
 	require.NoError(t, err)

--- a/src/util/util_all.go
+++ b/src/util/util_all.go
@@ -7,6 +7,7 @@ package util
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/client"
@@ -27,10 +28,10 @@ func PopulateFromDocker(i *integration.Integration, args config.ArgumentList) {
 	ExitOnErr(err)
 	defer dockerClient.Close()
 
-	fetcher := dockerapi.NewFetcher(dockerClient)
+	fetcher := dockerapi.NewFetcher(dockerClient, runtime.GOOS)
 
 	sampler, err := nri.NewSampler(fetcher, dockerClient, args)
 	ExitOnErr(err)
-	// always use dockerAPI for windows
+	// always use dockerAPI if not on Linux
 	ExitOnErr(sampler.SampleAll(context.Background(), i, system.Info{}))
 }

--- a/src/util/util_linux.go
+++ b/src/util/util_linux.go
@@ -10,6 +10,7 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
 	"github.com/newrelic/infra-integrations-sdk/v3/log"
 	"github.com/newrelic/nri-docker/src/config"
+	"github.com/newrelic/nri-docker/src/constants"
 	"github.com/newrelic/nri-docker/src/nri"
 	"github.com/newrelic/nri-docker/src/raw"
 	"github.com/newrelic/nri-docker/src/raw/dockerapi"
@@ -42,7 +43,7 @@ func PopulateFromDocker(i *integration.Integration, args config.ArgumentList) {
 
 	var fetcher raw.Fetcher
 	if UseDockerAPI(args.UseDockerAPI, cgroupInfo.CgroupVersion) {
-		fetcher = dockerapi.NewFetcher(dockerClient)
+		fetcher = dockerapi.NewFetcher(dockerClient, constants.LinuxPlatformName)
 	} else { // use cgroups as source of data
 		fetcher, err = raw.NewCgroupFetcher(args.HostRoot, cgroupInfo)
 		ExitOnErr(err)

--- a/test/integration/dockerapi_fetcher_test.go
+++ b/test/integration/dockerapi_fetcher_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/newrelic/nri-docker/src/constants"
 	"github.com/newrelic/nri-docker/src/raw/dockerapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,7 +20,7 @@ func TestDockerAPIFetcher(t *testing.T) {
 		t.Skip("DockerAPIFetcher only supports cgroups v2 version")
 	}
 
-	fetcher := dockerapi.NewFetcher(dockerClient)
+	fetcher := dockerapi.NewFetcher(dockerClient, constants.LinuxPlatformName)
 
 	// run a container for testing purposes
 	containerID, dockerRM := stress(t, "stress-ng", "-c", "2", "-l", "50", "-t", "5m", "--iomix", "10")

--- a/test/integration/metrics_test.go
+++ b/test/integration/metrics_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/newrelic/nri-docker/src/biz"
+	"github.com/newrelic/nri-docker/src/constants"
 	"github.com/newrelic/nri-docker/src/raw"
 	"github.com/newrelic/nri-docker/src/raw/dockerapi"
 )
@@ -52,7 +53,7 @@ func TestCompareMetrics(t *testing.T) {
 		t.Skip("DockerAPIFetcher only supports cgroups v2 version")
 	}
 
-	fetcherAPI := dockerapi.NewFetcher(dockerClient)
+	fetcherAPI := dockerapi.NewFetcher(dockerClient, constants.LinuxPlatformName)
 	metricsAPI := biz.NewProcessor(
 		persist.NewInMemoryStore(),
 		fetcherAPI,
@@ -440,7 +441,7 @@ func TestBlkIOMetrics(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			client := mockDockerStatsClient{}
 			client.On("ContainerStats", mock.Anything).Return(tc.MockStats)
-			dockerAPIFetcher := dockerapi.NewFetcher(&client)
+			dockerAPIFetcher := dockerapi.NewFetcher(&client, constants.LinuxPlatformName)
 
 			storer := inMemoryStorerWithPreviousCPUState()
 			inspector := NewInspectorMock(InspectorContainerID, InspectorPID, 2, nil)


### PR DESCRIPTION
There are no changes for Network metrics for windows. Therefore, just doing some housekeeping here. Adding platfrom to use for Memory and CPU metrics.