### PR TITLE
fix: use a separate config file for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### bugfix
+- fix config file for windows to remove unnecessary condition
+
 ## v2.3.0 - 2025-03-11
 
 ### 🚀 Enhancements

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -80,7 +80,7 @@ archives:
       - nri-win
     name_template: "{{ .ProjectName }}-{{ .Arch }}.{{ .Version }}_dirty"
     files:
-      - docker-config.yml
+      - docker-config-win.yml
       - docker-win-definition.yml
     format: zip
 

--- a/docker-config-win.yml
+++ b/docker-config-win.yml
@@ -1,0 +1,13 @@
+integrations:
+  - name: nri-docker
+    when:
+      feature: docker_enabled
+    interval: 15s
+  # This configuration is no longer included in nri-ecs images.
+  # it is kept for legacy reasons, but the new one is located in https://github.com/newrelic/nri-ecs
+  - name: nri-docker
+    when:
+      feature: docker_enabled
+      env_exists:
+        FARGATE: "true"
+    interval: 15s


### PR DESCRIPTION
Removed `file_exists: /var/run/docker.sock` from the linux config for windows.