### PR TITLE
Nr 375198 update cpu memory metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### enhancements
+- Add cpuLimitCores metric for windows
+
 ## v2.3.1 - 2025-03-25
 
 ### 🐞 Bug fixes

--- a/src/biz/metrics.go
+++ b/src/biz/metrics.go
@@ -156,7 +156,7 @@ func (mc *MetricsFetcher) Process(containerID string) (Sample, error) {
 	metrics.BlkIO = mc.blkIO(rawMetrics.Blkio)
 	metrics.CPU = mc.cpu(rawMetrics, &json)
 	metrics.Pids = Pids(rawMetrics.Pids)
-	metrics.Memory = mc.memory(rawMetrics.Memory)
+	metrics.Memory = mc.memory(rawMetrics.Memory, &json)
 	metrics.RestartCount = json.RestartCount
 
 	return metrics, nil

--- a/src/biz/metrics_all.go
+++ b/src/biz/metrics_all.go
@@ -14,7 +14,7 @@ import (
 	"github.com/newrelic/nri-docker/src/raw"
 )
 
-func (mc *MetricsFetcher) memory(mem raw.Memory) Memory {
+func (mc *MetricsFetcher) memory(mem raw.Memory, _ *types.ContainerJSON) Memory {
 	memLimits := mem.UsageLimit
 	// ridiculously large memory limits are set to 0 (no limit)
 	if memLimits > math.MaxInt64/2 {

--- a/src/biz/metrics_all_test.go
+++ b/src/biz/metrics_all_test.go
@@ -226,7 +226,7 @@ func TestMetricsFetcher_memory(t *testing.T) {
 				inspector:          tt.fields.inspector,
 				exitedContainerTTL: tt.fields.exitedContainerTTL,
 			}
-			if got := mc.memory(tt.args.mem); !reflect.DeepEqual(got, tt.want) {
+			if got := mc.memory(tt.args.mem, &types.ContainerJSON{}); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("MetricsFetcher.memory() = %v, want %v", got, tt.want)
 			}
 		})

--- a/src/biz/metrics_windows.go
+++ b/src/biz/metrics_windows.go
@@ -87,10 +87,8 @@ func (mc *MetricsFetcher) cpu(metrics raw.Metrics, containerJSON *types.Containe
 // if the container config is not available
 func getTotalMemory(containerJSON *types.ContainerJSON) uint64 {
 	var totalMemory uint64
-	if containerJSON != nil {
-		if containerJSON.HostConfig != nil && containerJSON.HostConfig.Memory > 0 {
-			totalMemory = uint64(containerJSON.HostConfig.Memory)
-		}
+	if containerJSON.HostConfig != nil && containerJSON.HostConfig.Memory > 0 {
+		totalMemory = uint64(containerJSON.HostConfig.Memory)
 	} else {
 		vmem, err := gops_mem.VirtualMemory()
 

--- a/src/biz/metrics_windows_test.go
+++ b/src/biz/metrics_windows_test.go
@@ -285,3 +285,32 @@ func TestGetNumOfLimitCores(t *testing.T) {
 		})
 	}
 }
+
+func TestGetTotalMemory(t *testing.T) {
+	tests := []struct {
+		name          string
+		containerJSON *types.ContainerJSON
+		want          uint64
+	}{
+		{
+			name: "Test with Memory set",
+			containerJSON: &types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					HostConfig: &container.HostConfig{
+						Resources: container.Resources{
+							Memory: 2147483648, // 2 GiB
+						},
+					},
+				},
+			},
+			want: 2147483648,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getTotalMemory(tt.containerJSON)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/src/biz/metrics_windows_test.go
+++ b/src/biz/metrics_windows_test.go
@@ -37,6 +37,7 @@ func TestCPU(t *testing.T) {
 			want: CPU{
 				CPUPercent:    0,
 				NumProcs:      2,
+				LimitCores:    2,
 				UserPercent:   0,
 				KernelPercent: 0,
 			},
@@ -69,6 +70,7 @@ func TestCPU(t *testing.T) {
 			want: CPU{
 				CPUPercent:    50,
 				NumProcs:      2,
+				LimitCores:    2,
 				UserPercent:   100,
 				KernelPercent: 0,
 			},
@@ -101,6 +103,7 @@ func TestCPU(t *testing.T) {
 			want: CPU{
 				CPUPercent:    50,
 				NumProcs:      2,
+				LimitCores:    2,
 				UserPercent:   0,
 				KernelPercent: 100,
 			},
@@ -133,6 +136,7 @@ func TestCPU(t *testing.T) {
 			want: CPU{
 				CPUPercent:    50,
 				NumProcs:      2,
+				LimitCores:    2,
 				UserPercent:   50,
 				KernelPercent: 50,
 			},
@@ -161,6 +165,7 @@ func TestCPU(t *testing.T) {
 			want: CPU{
 				CPUPercent:    50,
 				NumProcs:      2,
+				LimitCores:    2,
 				UserPercent:   0,
 				KernelPercent: 0,
 			},

--- a/src/nri/sampler_windows.go
+++ b/src/nri/sampler_windows.go
@@ -14,6 +14,7 @@ func memory(mem *biz.Memory) []entry {
 
 func cpu(cpu *biz.CPU) []entry {
 	return []entry{
+		metricCPULimitCores(cpu.LimitCores),
 		metricCPUPercent(cpu.CPUPercent),
 		metricCPUKernelPercent(cpu.KernelPercent),
 		metricCPUUserPercent(cpu.UserPercent),


### PR DESCRIPTION
* feat(windows): add cpuCount metric
* feat(windows): use totalMemroy from config if available

With below command:
`docker run --rm --cpu-count=1 --memory=2GB -it mcr.microsoft.com/windows/nanoserver:ltsc2022 cmd`
Resulting metrics:
```powershell
PS C:\Program Files\New Relic\newrelic-infra\newrelic-integrations\bin> .\nri-docker.exe --pretty --verbose
[WARN] computing Storage Driver stats: only devicemapper is supported
[DEBUG] Could not fetch metric value from docker API: the key "file" was not found in memory_stats.stats
[DEBUG] Could not fetch metric value from docker API: the key "anon" was not found in memory_stats.stats
[DEBUG] Could not fetch metric value from docker API: the key "kernel_stack" was not found in memory_stats.stats
[DEBUG] Could not fetch metric value from docker API: the key "slab" was not found in memory_stats.stats
[DEBUG] passIntervals: 20109624, intervalsUsed: 0
[DEBUG] total memory on system: 2147483648
[DEBUG] memory usage percent: 1.436614990234375
{
        "name": "com.newrelic.docker",
        "protocol_version": "3",
        "integration_version": "0.0.0",
        "data": [
                {
                        "entity": {
                                "name": "88a9a24d018681518e4049aa9086fb2bea1d8e8b98958d19970705172005c7aa",
                                "type": "docker",
                                "id_attributes": []
                        },
                        "metrics": [
                                {
                                        "commandLine": "cmd",
                                        "containerId": "88a9a24d018681518e4049aa9086fb2bea1d8e8b98958d19970705172005c7aa",
                                        "cpuKernelPercent": 0,
                                        "cpuLimitCores": 1,
                                        "cpuPercent": 0,
                                        "cpuProcs": 2,
                                        "cpuUserPercent": 0,
                                        "event_type": "ContainerSample",
                                        "image": "sha256:33403772621bc2917c21db51c382eee8f52ef3442e8d71f792066ba1ace9de16",
                                        "imageName": "mcr.microsoft.com/windows/nanoserver:ltsc2022",
                                        "ioReadCountNormalized": 6685,
                                        "ioTotalBytes": 60225024,
                                        "ioTotalReadBytes": 51164672,
                                        "ioTotalWriteBytes": 9060352,
                                        "ioWriteCountNormalized": 1210,
                                        "memoryCommitBytes": 43003904,
                                        "memoryCommitPeakBytes": 96280576,
                                        "memoryPrivateWorkingSet": 30851072,
                                        "memoryUsageLimitPercent": 1.436614990234375,
                                        "name": "stupefied_rosalind",
                                        "networkRxBytes": 436561,
                                        "networkRxBytesPerSecond": 0,
                                        "networkRxDropped": 0,
                                        "networkRxDroppedPerSecond": 0,
                                        "networkRxErrors": 0,
                                        "networkRxErrorsPerSecond": 0,
                                        "networkRxPackets": 128,
                                        "networkRxPacketsPerSecond": 0,
                                        "networkTxBytes": 19805,
                                        "networkTxBytesPerSecond": 0,
                                        "networkTxDropped": 0,
                                        "networkTxDroppedPerSecond": 0,
                                        "networkTxErrors": 0,
                                        "networkTxErrorsPerSecond": 0,
                                        "networkTxPackets": 166,
                                        "networkTxPacketsPerSecond": 0,
                                        "restartCount": 0,
                                        "shortContainerId": "88a9a24d0186",
                                        "state": "running",
                                        "status": "Up 6 minutes"
                                }
                        ],
                        "inventory": {},
                        "events": []
                }
        ]
}
```