### PR TITLE
NR-403516: move all pipelines from ubuntu-20 runners to ubuntu-latest

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,7 +11,7 @@ jobs:
   e2eTests-cgroups-v1:
     # Do not run e2e tests if commit message or PR has skip-e2e.
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check cgroups version
         run: |

--- a/.github/workflows/on_push_pr.yaml
+++ b/.github/workflows/on_push_pr.yaml
@@ -13,7 +13,7 @@ jobs:
 
   test-integration-nix-cgroups-v1:
     name: Run integration tests on *Nix cgroups-v1
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check cgroups version
         run: |


### PR DESCRIPTION
### Context

This pull request is driven by the upcoming deprecation of the Ubuntu 20.04 Actions runner image. GitHub has announced the following timeline for deprecation:

- **Deprecation Start Date**: 2025-02-01
- **Full Unsupported Date**: 2025-04-15

Given these dates, it is crucial to transition to supported runner images to ensure that our CI/CD pipelines do not encounter disruptions.

### Change Description

- **Objective**: Update all pipelines to use the `ubuntu-latest` runner image instead of the soon-to-be deprecated `ubuntu-20.xx`.
- **Background**: By updating to `ubuntu-latest`, we align our workflows with the latest stable and supported environment that GitHub provides. 
- **Impact**: Workflows using the `ubuntu-20.04` image label should be updated to `ubuntu-latest`.

