### PR TITLE
NR-403516: Move all pipelines from ubuntu-20 runners to ubuntu-latest

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,7 +11,7 @@ jobs:
   e2eTests-cgroups-v1:
     # Do not run e2e tests if commit message or PR has skip-e2e.
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check cgroups version
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,33 +8,6 @@ on:
   pull_request:
 
 jobs:
-  e2eTests-cgroups-v1:
-    # Do not run e2e tests if commit message or PR has skip-e2e.
-    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check cgroups version
-        run: |
-          if [ $(docker info --format '{{.CgroupVersion}}') != "1" ]; then
-              echo "This test must be run in cgroups v1"
-              exit 1
-          fi
-      - name: checkout-repository
-        uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-      - name: Compile nri-docker
-        run: |
-          GOOS=linux GOARCH=amd64 make compile
-      - name: Run E2E for Cgroups v1
-        uses: newrelic/newrelic-integration-e2e-action@v1
-        with:
-          spec_path: test/e2e/e2e_spec.yml
-          account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
-          api_key: ${{ secrets.COREINT_E2E_API_KEY }}
-          license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
   e2eTests-cgroups-v2:
     # Do not run e2e tests if commit message or PR has skip-e2e.
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}

--- a/.github/workflows/on_push_pr.yaml
+++ b/.github/workflows/on_push_pr.yaml
@@ -13,7 +13,7 @@ jobs:
 
   test-integration-nix-cgroups-v1:
     name: Run integration tests on *Nix cgroups-v1
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check cgroups version
         run: |

--- a/.github/workflows/on_push_pr.yaml
+++ b/.github/workflows/on_push_pr.yaml
@@ -10,20 +10,3 @@ on:
 jobs:
   push-pr:
     uses: newrelic/coreint-automation/.github/workflows/reusable_push_pr.yaml@v3
-
-  test-integration-nix-cgroups-v1:
-    name: Run integration tests on *Nix cgroups-v1
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check cgroups version
-        run: |
-          if [ $(docker info --format '{{.CgroupVersion}}') != "1" ]; then
-              echo "This test must be run in cgroups v1"
-              exit 1
-          fi
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-      - name: Integration test
-        run: make integration-test


### PR DESCRIPTION
### Context

This pull request is driven by the upcoming deprecation of the Ubuntu 20.04 Actions runner image. GitHub has announced the following timeline for deprecation:

- **Deprecation Start Date**: 2025-02-01
- **Full Unsupported Date**: 2025-04-15

Given these dates, it is crucial to transition to supported runner images to ensure that our CI/CD pipelines do not encounter disruptions.

### Change Description

- **Objective**: Update all pipelines to use the `ubuntu-latest` runner image instead of the soon-to-be deprecated `ubuntu-20.xx`.
- **Background**: By updating to `ubuntu-latest`, we align our workflows with the latest stable and supported environment that GitHub provides. 
- **Impact**: Workflows using the `ubuntu-20.04` image label should be updated to `ubuntu-latest`.

